### PR TITLE
GRAL-2086: add lead_id support to notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3250,14 +3250,16 @@ function getAllNotes($options)
 | Parameter | Tags | Description |
 |-----------|------|-------------|
 | userId |  ``` Optional ```  | ID of the user whose notes to fetch. If omitted, notes by all users will be returned. |
-| dealId |  ``` Optional ```  | ID of the deal which notes to fetch. If omitted, notes about all deals with be returned. |
-| personId |  ``` Optional ```  | ID of the person whose notes to fetch. If omitted, notes about all persons with be returned. |
-| orgId |  ``` Optional ```  | ID of the organization which notes to fetch. If omitted, notes about all organizations with be returned. |
+| leadId |  ``` Optional ```  | ID of the lead which notes to fetch. If omitted, notes about all leads will be returned. |
+| dealId |  ``` Optional ```  | ID of the deal which notes to fetch. If omitted, notes about all deals will be returned. |
+| personId |  ``` Optional ```  | ID of the person whose notes to fetch. If omitted, notes about all persons will be returned. |
+| orgId |  ``` Optional ```  | ID of the organization which notes to fetch. If omitted, notes about all organizations will be returned. |
 | start |  ``` Optional ```  ``` DefaultValue ```  | Pagination start |
 | limit |  ``` Optional ```  | Items shown per page |
 | sort |  ``` Optional ```  | Field names and sorting mode separated by a comma (field_name_1 ASC, field_name_2 DESC). Only first-level field keys are supported (no nested keys). Supported fields: id, user_id, deal_id, person_id, org_id, content, add_time, update_time. |
 | startDate |  ``` Optional ```  | Date in format of YYYY-MM-DD from which notes to fetch from. |
 | endDate |  ``` Optional ```  | Date in format of YYYY-MM-DD until which notes to fetch to. |
+| pinnedToLeadlFlag |  ``` Optional ```  | If set, then results are filtered by note to lead pinning state. |
 | pinnedToDealFlag |  ``` Optional ```  | If set, then results are filtered by note to deal pinning state. |
 | pinnedToOrganizationFlag |  ``` Optional ```  | If set, then results are filtered by note to organization pinning state. |
 | pinnedToPersonFlag |  ``` Optional ```  | If set, then results are filtered by note to person pinning state. |
@@ -3269,6 +3271,9 @@ function getAllNotes($options)
 ```php
 $userId = 69;
 $collect['userId'] = $userId;
+
+$leadId = 'adf21080-0e10-11eb-879b-05d71fb426ec';
+$collect['leadId'] = $leadId;
 
 $dealId = 69;
 $collect['dealId'] = $dealId;
@@ -3293,6 +3298,9 @@ $collect['startDate'] = $startDate;
 
 $endDate = date("D M d, Y G:i");
 $collect['endDate'] = $endDate;
+
+$pinnedToLeadFlag = int::ENUM_0;
+$collect['pinnedToLeadFlag'] = $pinnedToLeadFlag;
 
 $pinnedToDealFlag = int::ENUM_0;
 $collect['pinnedToDealFlag'] = $pinnedToDealFlag;
@@ -3324,10 +3332,12 @@ function addANote($options)
 |-----------|------|-------------|
 | content |  ``` Required ```  | Content of the note in HTML format. Subject to sanitization on the back-end. |
 | userId |  ``` Optional ```  | ID of the user who will be marked as the author of this note. Only an admin can change the author. |
+| leadId |  ``` Optional ```  | ID of the lead the note will be attached to. |
 | dealId |  ``` Optional ```  | ID of the deal the note will be attached to. |
 | personId |  ``` Optional ```  | ID of the person this note will be attached to. |
 | orgId |  ``` Optional ```  | ID of the organization this note will be attached to. |
 | addTime |  ``` Optional ```  | Optional creation date & time of the Note in UTC. Can be set in the past or in the future. Requires admin user API token. Format: YYYY-MM-DD HH:MM:SS |
+| pinnedToLeadFlag |  ``` Optional ```  | If set, then results are filtered by note to lead pinning state (lead_id is also required). |
 | pinnedToDealFlag |  ``` Optional ```  | If set, then results are filtered by note to deal pinning state (deal_id is also required). |
 | pinnedToOrganizationFlag |  ``` Optional ```  | If set, then results are filtered by note to organization pinning state (org_id is also required). |
 | pinnedToPersonFlag |  ``` Optional ```  | If set, then results are filtered by note to person pinning state (person_id is also required). |
@@ -3343,6 +3353,9 @@ $collect['content'] = $content;
 $userId = 69;
 $collect['userId'] = $userId;
 
+$leadId = 'adf21080-0e10-11eb-879b-05d71fb426ec';
+$collect['leadId'] = $leadId;
+
 $dealId = 69;
 $collect['dealId'] = $dealId;
 
@@ -3354,6 +3367,9 @@ $collect['orgId'] = $orgId;
 
 $addTime = 'add_time';
 $collect['addTime'] = $addTime;
+
+$pinnedToLeadFlag = int::ENUM_0;
+$collect['pinnedToLeadFlag'] = $pinnedToLeadFlag;
 
 $pinnedToDealFlag = int::ENUM_0;
 $collect['pinnedToDealFlag'] = $pinnedToDealFlag;
@@ -3440,10 +3456,12 @@ function updateANote($options)
 | id |  ``` Required ```  | ID of the note |
 | content |  ``` Required ```  | Content of the note in HTML format. Subject to sanitization on the back-end. |
 | userId |  ``` Optional ```  | ID of the user who will be marked as the author of this note. Only an admin can change the author. |
+| leadId |  ``` Optional ```  | ID of the lead the note will be attached to. |
 | dealId |  ``` Optional ```  | ID of the deal the note will be attached to. |
 | personId |  ``` Optional ```  | ID of the person this note will be attached to. |
 | orgId |  ``` Optional ```  | ID of the organization this note will be attached to. |
 | addTime |  ``` Optional ```  | Optional creation date & time of the Note in UTC. Can be set in the past or in the future. Requires admin user API token. Format: YYYY-MM-DD HH:MM:SS |
+| pinnedToLeadFlag |  ``` Optional ```  | If set, then results are filtered by note to lead pinning state (lead_id is also required). |
 | pinnedToDealFlag |  ``` Optional ```  | If set, then results are filtered by note to deal pinning state (deal_id is also required). |
 | pinnedToOrganizationFlag |  ``` Optional ```  | If set, then results are filtered by note to organization pinning state (org_id is also required). |
 | pinnedToPersonFlag |  ``` Optional ```  | If set, then results are filtered by note to person pinning state (person_id is also required). |
@@ -3462,6 +3480,9 @@ $collect['content'] = $content;
 $userId = 69;
 $collect['userId'] = $userId;
 
+$leadId = 'adf21080-0e10-11eb-879b-05d71fb426ec';
+$collect['leadId'] = $leadId;
+
 $dealId = 69;
 $collect['dealId'] = $dealId;
 
@@ -3473,6 +3494,9 @@ $collect['orgId'] = $orgId;
 
 $addTime = 'add_time';
 $collect['addTime'] = $addTime;
+
+$pinnedToLeadFlag = int::ENUM_0;
+$collect['pinnedToLeadFlag'] = $pinnedToLeadFlag;
 
 $pinnedToDealFlag = int::ENUM_0;
 $collect['pinnedToDealFlag'] = $pinnedToDealFlag;

--- a/src/Controllers/NotesController.php
+++ b/src/Controllers/NotesController.php
@@ -50,12 +50,14 @@ class NotesController extends BaseController
      * @param  array  $options    Array with all options for search
      * @param integer  $options['userId']                      (optional) ID of the user whose notes to fetch. If
      *                                                         omitted, notes by all users will be returned.
+     * @param string  $options['leadId']                       (optional) ID of the lead which notes to fetch. If
+     *                                                         omitted, notes about all leads will be returned.
      * @param integer  $options['dealId']                      (optional) ID of the deal which notes to fetch. If
-     *                                                         omitted, notes about all deals with be returned.
+     *                                                         omitted, notes about all deals will be returned.
      * @param integer  $options['personId']                    (optional) ID of the person whose notes to fetch. If
-     *                                                         omitted, notes about all persons with be returned.
+     *                                                         omitted, notes about all persons will be returned.
      * @param integer  $options['orgId']                       (optional) ID of the organization which notes to fetch.
-     *                                                         If omitted, notes about all organizations with be
+     *                                                         If omitted, notes about all organizations will be
      *                                                         returned.
      * @param integer  $options['start']                       (optional) Pagination start
      * @param integer  $options['limit']                       (optional) Items shown per page
@@ -68,6 +70,8 @@ class NotesController extends BaseController
      *                                                         to fetch from.
      * @param DateTime $options['endDate']                     (optional) Date in format of YYYY-MM-DD until which
      *                                                         notes to fetch to.
+     * @param int      $options['pinnedToLeadFlag']            (optional) If set, then results are filtered by note to
+     *                                                         lead pinning state.
      * @param int      $options['pinnedToDealFlag']            (optional) If set, then results are filtered by note to
      *                                                         deal pinning state.
      * @param int      $options['pinnedToOrganizationFlag']    (optional) If set, then results are filtered by note to
@@ -89,6 +93,7 @@ class NotesController extends BaseController
         //process optional query parameters
         APIHelper::appendUrlWithQueryParameters($_queryBuilder, array (
             'user_id'                     => $this->val($options, 'userId'),
+            'lead_id'                     => $this->val($options, 'leadId'),
             'deal_id'                     => $this->val($options, 'dealId'),
             'person_id'                   => $this->val($options, 'personId'),
             'org_id'                      => $this->val($options, 'orgId'),
@@ -97,6 +102,7 @@ class NotesController extends BaseController
             'sort'                        => $this->val($options, 'sort'),
             'start_date'                  => DateTimeHelper::toSimpleDate($this->val($options, 'startDate')),
             'end_date'                    => DateTimeHelper::toSimpleDate($this->val($options, 'endDate')),
+            'pinned_to_lead_flag'         => $this->val($options, 'pinnedToLeadFlag'),
             'pinned_to_deal_flag'         => $this->val($options, 'pinnedToDealFlag'),
             'pinned_to_organization_flag' => $this->val($options, 'pinnedToOrganizationFlag'),
             'pinned_to_person_flag'       => $this->val($options, 'pinnedToPersonFlag'),
@@ -145,6 +151,7 @@ class NotesController extends BaseController
      *                                                        sanitization on the back-end.
      * @param integer $options['userId']                      (optional) ID of the user who will be marked as the
      *                                                        author of this note. Only an admin can change the author.
+     * @param string $options['leadId']                       (optional) ID of the lead the note will be attached to.
      * @param integer $options['dealId']                      (optional) ID of the deal the note will be attached to.
      * @param integer $options['personId']                    (optional) ID of the person this note will be attached to.
      * @param integer $options['orgId']                       (optional) ID of the organization this note will be
@@ -152,6 +159,8 @@ class NotesController extends BaseController
      * @param string  $options['addTime']                     (optional) Optional creation date & time of the Note in
      *                                                        UTC. Can be set in the past or in the future. Requires
      *                                                        admin user API token. Format: YYYY-MM-DD HH:MM:SS
+     * @param int     $options['pinnedToLeadFlag']            (optional) If set, then results are filtered by note to
+     *                                                        lead pinning state (lead_id is also required).
      * @param int     $options['pinnedToDealFlag']            (optional) If set, then results are filtered by note to
      *                                                        deal pinning state (deal_id is also required).
      * @param int     $options['pinnedToOrganizationFlag']    (optional) If set, then results are filtered by note to
@@ -184,10 +193,12 @@ class NotesController extends BaseController
         $_parameters = array (
             'content'                     => $this->val($options, 'content'),
             'user_id'                     => $this->val($options, 'userId'),
+            'lead_id'                     => $this->val($options, 'leadId'),
             'deal_id'                     => $this->val($options, 'dealId'),
             'person_id'                   => $this->val($options, 'personId'),
             'org_id'                      => $this->val($options, 'orgId'),
             'add_time'                    => $this->val($options, 'addTime'),
+            'pinned_to_lead_flag'       => APIHelper::prepareFormFields($this->val($options, 'pinnedToLeadFlag')),
             'pinned_to_deal_flag'       => APIHelper::prepareFormFields($this->val($options, 'pinnedToDealFlag')),
             'pinned_to_organization_flag' => APIHelper::prepareFormFields($this->val($options, 'pinnedToOrganizationFlag')),
             'pinned_to_person_flag'     => APIHelper::prepareFormFields($this->val($options, 'pinnedToPersonFlag'))
@@ -339,6 +350,7 @@ class NotesController extends BaseController
      *                                                        sanitization on the back-end.
      * @param integer $options['userId']                      (optional) ID of the user who will be marked as the
      *                                                        author of this note. Only an admin can change the author.
+     * @param string $options['leadId']                       (optional) ID of the lead the note will be attached to.
      * @param integer $options['dealId']                      (optional) ID of the deal the note will be attached to.
      * @param integer $options['personId']                    (optional) ID of the person this note will be attached to.
      * @param integer $options['orgId']                       (optional) ID of the organization this note will be
@@ -346,6 +358,8 @@ class NotesController extends BaseController
      * @param string  $options['addTime']                     (optional) Optional creation date & time of the Note in
      *                                                        UTC. Can be set in the past or in the future. Requires
      *                                                        admin user API token. Format: YYYY-MM-DD HH:MM:SS
+     * @param int     $options['pinnedToLeadFlag']            (optional) If set, then results are filtered by note to
+     *                                                        lead pinning state (lead_id is also required).
      * @param int     $options['pinnedToDealFlag']            (optional) If set, then results are filtered by note to
      *                                                        deal pinning state (deal_id is also required).
      * @param int     $options['pinnedToOrganizationFlag']    (optional) If set, then results are filtered by note to
@@ -383,10 +397,12 @@ class NotesController extends BaseController
         $_parameters = array (
             'content'                     => $this->val($options, 'content'),
             'user_id'                     => $this->val($options, 'userId'),
+            'lead_id'                     => $this->val($options, 'leadId'),
             'deal_id'                     => $this->val($options, 'dealId'),
             'person_id'                   => $this->val($options, 'personId'),
             'org_id'                      => $this->val($options, 'orgId'),
             'add_time'                    => $this->val($options, 'addTime'),
+            'pinned_to_lead_flag'       => APIHelper::prepareFormFields($this->val($options, 'pinnedToLeadFlag')),
             'pinned_to_deal_flag'       => APIHelper::prepareFormFields($this->val($options, 'pinnedToDealFlag')),
             'pinned_to_organization_flag' => APIHelper::prepareFormFields($this->val($options, 'pinnedToOrganizationFlag')),
             'pinned_to_person_flag'     => APIHelper::prepareFormFields($this->val($options, 'pinnedToPersonFlag'))

--- a/src/Models/BaseNote.php
+++ b/src/Models/BaseNote.php
@@ -47,6 +47,13 @@ class BaseNote implements JsonSerializable
     public $deal;
 
     /**
+     * The ID of the Lead the Note is attached to
+     * @maps lead_id
+     * @var string|null $leadId public property
+     */
+    public $leadId;
+
+    /**
      * The ID of the Deal the Note is attached to
      * @maps deal_id
      * @var integer|null $dealId public property
@@ -85,6 +92,13 @@ class BaseNote implements JsonSerializable
      * @var integer|null $personId public property
      */
     public $personId;
+
+    /**
+     * If true, then the results are filtered by Note to Lead pinning state.
+     * @maps pinned_to_lead_flag
+     * @var bool|null $pinnedToLeadFlag public property
+     */
+    public $pinnedToLeadFlag;
 
     /**
      * If true, then the results are filtered by Note to Deal pinning state.
@@ -134,12 +148,14 @@ class BaseNote implements JsonSerializable
      * @param string            $addTime                  Initialization value for $this->addTime
      * @param string            $content                  Initialization value for $this->content
      * @param BaseNoteDealTitle $deal                     Initialization value for $this->deal
+     * @param string            $leadId                   Initialization value for $this->leadId
      * @param integer           $dealId                   Initialization value for $this->dealId
      * @param integer           $lastUpdateUserId         Initialization value for $this->lastUpdateUserId
      * @param integer           $orgId                    Initialization value for $this->orgId
      * @param Organization      $organization             Initialization value for $this->organization
      * @param Person            $person                   Initialization value for $this->person
      * @param integer           $personId                 Initialization value for $this->personId
+     * @param bool              $pinnedToLeadFlag         Initialization value for $this->pinnedToLeadFlag
      * @param bool              $pinnedToDealFlag         Initialization value for $this->pinnedToDealFlag
      * @param bool              $pinnedToOrganizationFlag Initialization value for $this->pinnedToOrganizationFlag
      * @param bool              $pinnedToPersonFlag       Initialization value for $this->pinnedToPersonFlag
@@ -149,24 +165,26 @@ class BaseNote implements JsonSerializable
      */
     public function __construct()
     {
-        if (17 == func_num_args()) {
+        if (19 == func_num_args()) {
             $this->id                       = func_get_arg(0);
             $this->activeFlag               = func_get_arg(1);
             $this->addTime                  = func_get_arg(2);
             $this->content                  = func_get_arg(3);
             $this->deal                     = func_get_arg(4);
-            $this->dealId                   = func_get_arg(5);
-            $this->lastUpdateUserId         = func_get_arg(6);
-            $this->orgId                    = func_get_arg(7);
-            $this->organization             = func_get_arg(8);
-            $this->person                   = func_get_arg(9);
-            $this->personId                 = func_get_arg(10);
-            $this->pinnedToDealFlag         = func_get_arg(11);
-            $this->pinnedToOrganizationFlag = func_get_arg(12);
-            $this->pinnedToPersonFlag       = func_get_arg(13);
-            $this->updateTime               = func_get_arg(14);
-            $this->user                     = func_get_arg(15);
-            $this->userId                   = func_get_arg(16);
+            $this->leadId                   = func_get_arg(5);
+            $this->dealId                   = func_get_arg(6);
+            $this->lastUpdateUserId         = func_get_arg(7);
+            $this->orgId                    = func_get_arg(8);
+            $this->organization             = func_get_arg(9);
+            $this->person                   = func_get_arg(10);
+            $this->personId                 = func_get_arg(11);
+            $this->pinnedToLeadFlag         = func_get_arg(12);
+            $this->pinnedToDealFlag         = func_get_arg(13);
+            $this->pinnedToOrganizationFlag = func_get_arg(14);
+            $this->pinnedToPersonFlag       = func_get_arg(15);
+            $this->updateTime               = func_get_arg(16);
+            $this->user                     = func_get_arg(17);
+            $this->userId                   = func_get_arg(18);
         }
     }
 
@@ -182,12 +200,14 @@ class BaseNote implements JsonSerializable
         $json['add_time']                    = $this->addTime;
         $json['content']                     = $this->content;
         $json['deal']                        = $this->deal;
+        $json['lead_id']                     = $this->leadId;
         $json['deal_id']                     = $this->dealId;
         $json['last_update_user_id']         = $this->lastUpdateUserId;
         $json['org_id']                      = $this->orgId;
         $json['organization']                = $this->organization;
         $json['person']                      = $this->person;
         $json['person_id']                   = $this->personId;
+        $json['pinned_to_lead_flag']         = $this->pinnedToLeadFlag;
         $json['pinned_to_deal_flag']         = $this->pinnedToDealFlag;
         $json['pinned_to_organization_flag'] = $this->pinnedToOrganizationFlag;
         $json['pinned_to_person_flag']       = $this->pinnedToPersonFlag;

--- a/src/Models/Note.php
+++ b/src/Models/Note.php
@@ -29,6 +29,13 @@ class Note implements JsonSerializable
     public $userId;
 
     /**
+     * ID of the lead the note will be attached to.
+     * @maps lead_id
+     * @var string|null $leadId public property
+     */
+    public $leadId;
+
+    /**
      * ID of the deal the note will be attached to.
      * @maps deal_id
      * @var integer|null $dealId public property
@@ -58,6 +65,13 @@ class Note implements JsonSerializable
     public $addTime;
 
     /**
+     * If true, then the results are filtered by Note to Lead pinning state.
+     * @maps pinned_to_lead_flag
+     * @var bool|null $pinnedToLeadFlag public property
+     */
+    public $pinnedToLeadFlag;
+
+    /**
      * If set, then results are filtered by note to deal pinning state (deal_id is also required).
      * @maps pinned_to_deal_flag
      * @var int|null $pinnedToDealFlag public property
@@ -82,26 +96,30 @@ class Note implements JsonSerializable
      * Constructor to set initial or default values of member properties
      * @param string  $content                  Initialization value for $this->content
      * @param integer $userId                   Initialization value for $this->userId
+     * @param string  $leadId                   Initialization value for $this->leadId
      * @param integer $dealId                   Initialization value for $this->dealId
      * @param integer $personId                 Initialization value for $this->personId
      * @param integer $orgId                    Initialization value for $this->orgId
      * @param string  $addTime                  Initialization value for $this->addTime
+     * @param int     $pinnedToLeadFlag         Initialization value for $this->pinnedToLeadFlag
      * @param int     $pinnedToDealFlag         Initialization value for $this->pinnedToDealFlag
      * @param int     $pinnedToOrganizationFlag Initialization value for $this->pinnedToOrganizationFlag
      * @param int     $pinnedToPersonFlag       Initialization value for $this->pinnedToPersonFlag
      */
     public function __construct()
     {
-        if (9 == func_num_args()) {
+        if (11 == func_num_args()) {
             $this->content                  = func_get_arg(0);
             $this->userId                   = func_get_arg(1);
-            $this->dealId                   = func_get_arg(2);
-            $this->personId                 = func_get_arg(3);
-            $this->orgId                    = func_get_arg(4);
-            $this->addTime                  = func_get_arg(5);
-            $this->pinnedToDealFlag         = func_get_arg(6);
-            $this->pinnedToOrganizationFlag = func_get_arg(7);
-            $this->pinnedToPersonFlag       = func_get_arg(8);
+            $this->leadId                   = func_get_arg(2);
+            $this->dealId                   = func_get_arg(3);
+            $this->personId                 = func_get_arg(4);
+            $this->orgId                    = func_get_arg(5);
+            $this->addTime                  = func_get_arg(6);
+            $this->pinnedToLeadFlag         = func_get_arg(7);
+            $this->pinnedToDealFlag         = func_get_arg(8);
+            $this->pinnedToOrganizationFlag = func_get_arg(9);
+            $this->pinnedToPersonFlag       = func_get_arg(10);
         }
     }
 
@@ -114,10 +132,12 @@ class Note implements JsonSerializable
         $json = array();
         $json['content']                     = $this->content;
         $json['user_id']                     = $this->userId;
+        $json['lead_id']                     = $this->leadId;
         $json['deal_id']                     = $this->dealId;
         $json['person_id']                   = $this->personId;
         $json['org_id']                      = $this->orgId;
         $json['add_time']                    = $this->addTime;
+        $json['pinned_to_lead_flag']         = $this->pinnedToLeadFlag;
         $json['pinned_to_deal_flag']         = $this->pinnedToDealFlag;
         $json['pinned_to_organization_flag'] = $this->pinnedToOrganizationFlag;
         $json['pinned_to_person_flag']       = $this->pinnedToPersonFlag;


### PR DESCRIPTION
Added `lead_id` and `pinned_to_lead_flag` properties to Notes controller.

Testing:
* install this branch: `composer require pipedrive/pipedrive:dev-GRAL-2086-notes`
* check the README how to set up a simple sample script and try out the notes functions. For example, `$client->getNotes()->updateANote($options)` now returns:
```
(
    [success] => 1
    [data] => Pipedrive\Models\BaseNote Object
        (
            [id] => 123
            ...
            [leadId] => b0e0a1c0-xxxx-zzzz-xxxx-yyyyy8239447
            ...
            [pinnedToLeadFlag] => 1
            ...
        )
)
```