### PR TITLE
GRAL-2093: make sure all response properties are camelCased

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Or simply add it to your composer.json dependences and run `composer update`:
 
 ```json
 "require": {
-    "pipedrive/pipedrive": "^2.0"
+    "pipedrive/pipedrive": "^3.0"
 }
 ```
 

--- a/src/Controllers/BaseController.php
+++ b/src/Controllers/BaseController.php
@@ -24,7 +24,7 @@ class BaseController
      * User-agent to be sent with API calls
      * @var string
      */
-    const USER_AGENT = 'Pipedrive-SDK-PHP-1.0.0';
+    const USER_AGENT = 'Pipedrive-SDK-PHP-3.0.0';
 
     /**
      * HttpCallBack instance associated with this controller

--- a/src/Controllers/CurrenciesController.php
+++ b/src/Controllers/CurrenciesController.php
@@ -18,6 +18,7 @@ use Pipedrive\Http\HttpMethod;
 use Pipedrive\Http\HttpContext;
 use Pipedrive\OAuthManager;
 use Pipedrive\Servers;
+use Pipedrive\Utils\CamelCaseHelper;
 use Unirest\Request;
 
 /**
@@ -98,6 +99,6 @@ class CurrenciesController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\Currencies');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\Currencies'));
     }
 }

--- a/src/Controllers/DealsController.php
+++ b/src/Controllers/DealsController.php
@@ -98,7 +98,7 @@ class DealsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteMultipleDeals');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteMultipleDeals'));
     }
 
     /**
@@ -176,7 +176,7 @@ class DealsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GetDeals');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GetDeals'));
     }
 
     /**
@@ -235,7 +235,7 @@ class DealsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GetAddedDeal');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GetAddedDeal'));
     }
 
     /**
@@ -301,7 +301,7 @@ class DealsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GetDealsSummary');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GetDealsSummary'));
     }
 
     /**
@@ -393,7 +393,7 @@ class DealsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GetDealsTimeline');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GetDealsTimeline'));
     }
 
     /**
@@ -449,7 +449,7 @@ class DealsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteDeal');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteDeal'));
     }
 
     /**
@@ -510,7 +510,7 @@ class DealsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GetDeal');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GetDeal'));
     }
 
     /**
@@ -607,7 +607,7 @@ class DealsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GetAddedDeal');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GetAddedDeal'));
     }
 
     /**
@@ -730,7 +730,7 @@ class DealsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GetDuplicatedDeal');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GetDuplicatedDeal'));
     }
 
     /**
@@ -980,7 +980,7 @@ class DealsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\AddedDealFollower');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\AddedDealFollower'));
     }
 
     /**
@@ -1039,7 +1039,7 @@ class DealsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteDealFollower');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteDealFollower'));
     }
 
     /**
@@ -1166,7 +1166,7 @@ class DealsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GetMergedDeal');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GetMergedDeal'));
     }
 
     /**
@@ -1347,7 +1347,7 @@ class DealsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteDealParticipant');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteDealParticipant'));
     }
 
     /**
@@ -1590,7 +1590,7 @@ class DealsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GetAddProductAttachementDetails');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GetAddProductAttachementDetails'));
     }
 
     /**
@@ -1677,7 +1677,7 @@ class DealsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GetProductAttachementDetails');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GetProductAttachementDetails'));
     }
 
     /**
@@ -1738,7 +1738,7 @@ class DealsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteDealProduct');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteDealProduct'));
     }
 
     /**

--- a/src/Controllers/GlobalMessagesController.php
+++ b/src/Controllers/GlobalMessagesController.php
@@ -18,6 +18,7 @@ use Pipedrive\Http\HttpMethod;
 use Pipedrive\Http\HttpContext;
 use Pipedrive\OAuthManager;
 use Pipedrive\Servers;
+use Pipedrive\Utils\CamelCaseHelper;
 use Unirest\Request;
 
 /**
@@ -97,7 +98,7 @@ class GlobalMessagesController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GlobalMessageGet');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GlobalMessageGet'));
     }
 
     /**
@@ -153,6 +154,6 @@ class GlobalMessagesController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GlobalMessageDelete');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GlobalMessageDelete'));
     }
 }

--- a/src/Controllers/MailMessagesController.php
+++ b/src/Controllers/MailMessagesController.php
@@ -18,6 +18,7 @@ use Pipedrive\Http\HttpMethod;
 use Pipedrive\Http\HttpContext;
 use Pipedrive\OAuthManager;
 use Pipedrive\Servers;
+use Pipedrive\Utils\CamelCaseHelper;
 use Unirest\Request;
 
 /**
@@ -39,7 +40,7 @@ class MailMessagesController extends BaseController
         if (null === static::$instance) {
             static::$instance = new static();
         }
-        
+
         return static::$instance;
     }
 
@@ -104,7 +105,7 @@ class MailMessagesController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\MailMessage');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\MailMessage'));
     }
 
 

--- a/src/Controllers/MailThreadsController.php
+++ b/src/Controllers/MailThreadsController.php
@@ -18,6 +18,7 @@ use Pipedrive\Http\HttpMethod;
 use Pipedrive\Http\HttpContext;
 use Pipedrive\OAuthManager;
 use Pipedrive\Servers;
+use Pipedrive\Utils\CamelCaseHelper;
 use Unirest\Request;
 
 /**
@@ -101,7 +102,7 @@ class MailThreadsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\MailThread');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\MailThread'));
     }
 
     /**
@@ -157,7 +158,7 @@ class MailThreadsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\MailThreadDelete');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\MailThreadDelete'));
     }
 
     /**
@@ -213,7 +214,7 @@ class MailThreadsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\MailThreadOne');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\MailThreadOne'));
     }
 
     /**
@@ -282,7 +283,7 @@ class MailThreadsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\MailThreadPut');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\MailThreadPut'));
     }
 
     /**
@@ -338,7 +339,7 @@ class MailThreadsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\MailThreadMessages');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\MailThreadMessages'));
     }
 
 

--- a/src/Controllers/NotesController.php
+++ b/src/Controllers/NotesController.php
@@ -19,6 +19,7 @@ use Pipedrive\Http\HttpMethod;
 use Pipedrive\Http\HttpContext;
 use Pipedrive\OAuthManager;
 use Pipedrive\Servers;
+use Pipedrive\Utils\CamelCaseHelper;
 use Unirest\Request;
 
 /**
@@ -140,7 +141,7 @@ class NotesController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GetNotes');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GetNotes'));
     }
 
     /**
@@ -226,7 +227,7 @@ class NotesController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\PostNote');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\PostNote'));
     }
 
     /**
@@ -282,7 +283,7 @@ class NotesController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteNote');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteNote'));
     }
 
     /**
@@ -338,7 +339,7 @@ class NotesController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\PostNote');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\PostNote'));
     }
 
     /**
@@ -430,7 +431,7 @@ class NotesController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\PostNote');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\PostNote'));
     }
 
 

--- a/src/Controllers/PermissionSetsController.php
+++ b/src/Controllers/PermissionSetsController.php
@@ -18,6 +18,7 @@ use Pipedrive\Http\HttpMethod;
 use Pipedrive\Http\HttpContext;
 use Pipedrive\OAuthManager;
 use Pipedrive\Servers;
+use Pipedrive\Utils\CamelCaseHelper;
 use Unirest\Request;
 
 /**
@@ -94,7 +95,7 @@ class PermissionSetsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\PermissionSets');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\PermissionSets'));
     }
 
     /**
@@ -155,7 +156,7 @@ class PermissionSetsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\SinglePermissionSetsItem');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\SinglePermissionSetsItem'));
     }
 
     /**
@@ -225,7 +226,7 @@ class PermissionSetsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\UserAssignmentsToPermissionSet');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\UserAssignmentsToPermissionSet'));
     }
 
 

--- a/src/Controllers/ProductFieldsController.php
+++ b/src/Controllers/ProductFieldsController.php
@@ -18,6 +18,7 @@ use Pipedrive\Http\HttpMethod;
 use Pipedrive\Http\HttpContext;
 use Pipedrive\OAuthManager;
 use Pipedrive\Servers;
+use Pipedrive\Utils\CamelCaseHelper;
 use Unirest\Request;
 
 /**
@@ -96,7 +97,7 @@ class ProductFieldsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteMultipleProductFieldsResponse');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteMultipleProductFieldsResponse'));
     }
 
     /**
@@ -145,7 +146,7 @@ class ProductFieldsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GetAllProductFieldsResponse');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GetAllProductFieldsResponse'));
     }
 
     /**
@@ -202,7 +203,7 @@ class ProductFieldsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GetProductFieldResponse');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GetProductFieldResponse'));
     }
 
     /**
@@ -268,7 +269,7 @@ class ProductFieldsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteProductFieldResponse');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteProductFieldResponse'));
     }
 
     /**
@@ -332,7 +333,7 @@ class ProductFieldsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GetProductFieldResponse');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GetProductFieldResponse'));
     }
 
     /**
@@ -401,7 +402,7 @@ class ProductFieldsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GetProductFieldResponse');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GetProductFieldResponse'));
     }
 
 

--- a/src/Controllers/ProductsController.php
+++ b/src/Controllers/ProductsController.php
@@ -108,7 +108,7 @@ class ProductsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\Product');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\Product'));
     }
 
 
@@ -418,7 +418,7 @@ class ProductsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\Product');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\Product'));
     }
 
     /**
@@ -486,7 +486,7 @@ class ProductsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\BasicDeal');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\BasicDeal'));
     }
 
     /**
@@ -614,7 +614,7 @@ class ProductsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\UserIDs');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\UserIDs'));
     }
 
     /**
@@ -677,7 +677,7 @@ class ProductsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\NewFollowerResponse');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\NewFollowerResponse'));
     }
 
     /**
@@ -736,7 +736,7 @@ class ProductsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteProductFollowerResponse');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteProductFollowerResponse'));
     }
 
     /**
@@ -792,7 +792,7 @@ class ProductsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\UserIDs');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\UserIDs'));
     }
 
 

--- a/src/Controllers/RolesController.php
+++ b/src/Controllers/RolesController.php
@@ -18,6 +18,7 @@ use Pipedrive\Http\HttpMethod;
 use Pipedrive\Http\HttpContext;
 use Pipedrive\OAuthManager;
 use Pipedrive\Servers;
+use Pipedrive\Utils\CamelCaseHelper;
 use Unirest\Request;
 
 /**
@@ -99,7 +100,7 @@ class RolesController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GetRoles');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GetRoles'));
     }
 
     /**
@@ -154,7 +155,7 @@ class RolesController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\PostRoles');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\PostRoles'));
     }
 
     /**
@@ -210,7 +211,7 @@ class RolesController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteRole');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteRole'));
     }
 
     /**
@@ -266,7 +267,7 @@ class RolesController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GetRole');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GetRole'));
     }
 
     /**
@@ -331,7 +332,7 @@ class RolesController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\PutRole');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\PutRole'));
     }
 
     /**
@@ -394,7 +395,7 @@ class RolesController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteRoleAssignment');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\DeleteRoleAssignment'));
     }
 
     /**
@@ -459,7 +460,7 @@ class RolesController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GetRoleAssignments');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GetRoleAssignments'));
     }
 
     /**
@@ -522,7 +523,7 @@ class RolesController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\PostRoleAssignment');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\PostRoleAssignment'));
     }
 
     /**
@@ -587,7 +588,7 @@ class RolesController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GetRoleSubroles');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GetRoleSubroles'));
     }
 
     /**
@@ -643,7 +644,7 @@ class RolesController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\GetRoleSettings');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\GetRoleSettings'));
     }
 
     /**
@@ -708,7 +709,7 @@ class RolesController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\PostRoleSettings');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\PostRoleSettings'));
     }
 
 

--- a/src/Controllers/TeamsController.php
+++ b/src/Controllers/TeamsController.php
@@ -18,6 +18,7 @@ use Pipedrive\Http\HttpMethod;
 use Pipedrive\Http\HttpContext;
 use Pipedrive\OAuthManager;
 use Pipedrive\Servers;
+use Pipedrive\Utils\CamelCaseHelper;
 use Unirest\Request;
 
 /**
@@ -99,7 +100,7 @@ class TeamsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\Teams');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\Teams'));
     }
 
     /**
@@ -167,7 +168,7 @@ class TeamsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\Teams');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\Teams'));
     }
 
     /**
@@ -238,7 +239,7 @@ class TeamsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\Teams');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\Teams'));
     }
 
     /**
@@ -312,7 +313,7 @@ class TeamsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\Teams');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\Teams'));
     }
 
     /**
@@ -376,7 +377,7 @@ class TeamsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\UserIDs');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\UserIDs'));
     }
 
     /**
@@ -451,7 +452,7 @@ class TeamsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\UserIDs');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\UserIDs'));
     }
 
     /**
@@ -526,7 +527,7 @@ class TeamsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\UserIDs');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\UserIDs'));
     }
 
     /**
@@ -591,7 +592,7 @@ class TeamsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\Teams');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\Teams'));
     }
 
 

--- a/src/Controllers/UserConnectionsController.php
+++ b/src/Controllers/UserConnectionsController.php
@@ -18,6 +18,7 @@ use Pipedrive\Http\HttpMethod;
 use Pipedrive\Http\HttpContext;
 use Pipedrive\OAuthManager;
 use Pipedrive\Servers;
+use Pipedrive\Utils\CamelCaseHelper;
 use Unirest\Request;
 
 /**
@@ -94,6 +95,6 @@ class UserConnectionsController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\UserConnections');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\UserConnections'));
     }
 }

--- a/src/Controllers/UsersController.php
+++ b/src/Controllers/UsersController.php
@@ -90,7 +90,7 @@ class UsersController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\Users');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\Users'));
     }
 
     /**
@@ -157,7 +157,7 @@ class UsersController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\User');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\User'));
     }
 
     /**
@@ -217,7 +217,7 @@ class UsersController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\Users');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\Users'));
     }
 
     /**
@@ -273,7 +273,7 @@ class UsersController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\UserMe');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\UserMe'));
     }
 
     /**
@@ -337,7 +337,7 @@ class UsersController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\User');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\User'));
     }
 
     /**
@@ -413,7 +413,7 @@ class UsersController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\User');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\User'));
     }
 
     /**
@@ -589,7 +589,7 @@ class UsersController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\UserIDs');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\UserIDs'));
     }
 
     /**

--- a/src/Controllers/WebhooksController.php
+++ b/src/Controllers/WebhooksController.php
@@ -18,6 +18,7 @@ use Pipedrive\Http\HttpMethod;
 use Pipedrive\Http\HttpContext;
 use Pipedrive\OAuthManager;
 use Pipedrive\Servers;
+use Pipedrive\Utils\CamelCaseHelper;
 use Unirest\Request;
 
 /**
@@ -39,7 +40,7 @@ class WebhooksController extends BaseController
         if (null === static::$instance) {
             static::$instance = new static();
         }
-        
+
         return static::$instance;
     }
 
@@ -94,7 +95,7 @@ class WebhooksController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\WebhooksResponse');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\WebhooksResponse'));
     }
 
     /**
@@ -186,7 +187,7 @@ class WebhooksController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\WebhooksResponse1');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\WebhooksResponse1'));
     }
 
     /**
@@ -255,7 +256,7 @@ class WebhooksController extends BaseController
 
         $mapper = $this->getJsonMapper();
 
-        return $mapper->mapClass($response->body, 'Pipedrive\\Models\\Schema1');
+        return CamelCaseHelper::keysToCamelCase($mapper->mapClass($response->body, 'Pipedrive\\Models\\Schema1'));
     }
 
 

--- a/src/Utils/CamelCaseHelper.php
+++ b/src/Utils/CamelCaseHelper.php
@@ -11,8 +11,15 @@ class CamelCaseHelper
         }
 
         if (is_object($input)) {
-            $className = get_class($input);
-            $obj = new $className;
+            // If the input object is not an instance of any SDK model then use the JsonSerializer class
+            // so that json_encode() would use snake_case keys from the raw response.
+            // Otherwise, use the mapped model class where the snake_case keys are assigned by generated code.
+            if ($input instanceof \stdClass) {
+                $obj = new JsonSerializer($input);
+            } else {
+                $className = get_class($input);
+                $obj = new $className;
+            }
         }
 
         $arr = [];

--- a/src/Utils/CamelCaseHelper.php
+++ b/src/Utils/CamelCaseHelper.php
@@ -6,6 +6,10 @@ class CamelCaseHelper
 {
     public static function keysToCamelCase($input)
     {
+        if ($input instanceof \DateTime) {
+            return $input;
+        }
+
         if (is_object($input)) {
             $className = get_class($input);
             $obj = new $className;

--- a/src/Utils/CamelCaseHelper.php
+++ b/src/Utils/CamelCaseHelper.php
@@ -6,7 +6,11 @@ class CamelCaseHelper
 {
     public static function keysToCamelCase($input)
     {
-        $obj = new \stdClass();
+        if (is_object($input)) {
+            $className = get_class($input);
+            $obj = new $className;
+        }
+
         $arr = [];
 
         foreach ($input as $key => $value) {
@@ -18,11 +22,12 @@ class CamelCaseHelper
                 $key
             );
 
-            if (is_array($value) || is_object($value))
+            if (is_array($value) || is_object($value)) {
                 $value = CamelCaseHelper::keysToCamelCase($value);
+            }
 
             if (is_object($input)) {
-               $obj->{$key} = $value;
+                $obj->{$key} = $value;
             } else {
                 $arr[$key] = $value;
             }

--- a/src/Utils/JsonSerializer.php
+++ b/src/Utils/JsonSerializer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Pipedrive\Utils;
+
+use JsonSerializable;
+
+class JsonSerializer implements JsonSerializable
+{
+    private $args;
+
+    public function __construct($input)
+    {
+        $this->args = $input;
+    }
+
+    /**
+     * Encode this object to JSON
+     */
+    public function jsonSerialize()
+    {
+        return $this->args;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/pipedrive/client-php/issues/42

Every response now goes through `CamelCaseHelper::keysToCamelCase()` function because relying on only the model mapper caused inconsistencies (if the model contained a property that is defined just as an `object`, not a specific model - [like this one](https://github.com/pipedrive/client-php/blob/28e562416f7bc3c29b0e107247c7f046ba7b50c8/src/Models/Data21.php#L445-L447) - then the keys of this object were not camel-cased).

Also, if `json_encode()` is run over the response then everything is now consistently snake_cased (as in the raw response)

Testing:
* install this branch: `composer require pipedrive/pipedrive:dev-GRAL-2093-camel-case`
* check the README how to set up a simple sample script and try it out on controllers which use models which have plain objects defined as properties.

For example, `$client->getDeals()->getDetailsOfADeal(123);` now (left) vs before (right):
<img width="1262" alt="Markup 2021-07-01 at 12 20 26" src="https://user-images.githubusercontent.com/17141186/124155816-8e7acd80-da9f-11eb-9ae3-0859672acece.png">

