### PR TITLE
GRAL-2200: fix updating deals/persons/organizations optional and custom fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1350,7 +1350,7 @@ $result = $deals->getDetailsOfADeal($id);
 
 ### <a name="update_a_deal"></a>![Method: ](https://apidocs.io/img/method.png ".DealsController.updateADeal") updateADeal
 
-> Updates the properties of a deal. For more information on how to update a deal, see <a href="https://pipedrive.readme.io/docs/updating-a-deal" target="_blank" rel="noopener noreferrer">this tutorial</a>.
+> Updates the properties of a deal. Note that you can supply additional custom fields along with the request that are not described here. These custom fields are different for each Pipedrive account and can be recognized by long hashes as keys. To determine which custom fields exists, fetch the dealFields and look for 'key' values. For more information on how to update a deal, see <a href="https://pipedrive.readme.io/docs/updating-a-deal" target="_blank" rel="noopener noreferrer">this tutorial</a>.
 
 
 ```php
@@ -4059,7 +4059,7 @@ $organizations->getDetailsOfAnOrganization($id);
 
 ### <a name="update_an_organization"></a>![Method: ](https://apidocs.io/img/method.png ".OrganizationsController.updateAnOrganization") updateAnOrganization
 
-> Updates the properties of an organization.
+> Updates the properties of an organization. Note that you can supply additional custom fields along with the request that are not described here. These custom fields are different for each Pipedrive account and can be recognized by long hashes as keys. To determine which custom fields exists, fetch the organizationFields and look for 'key' values.
 
 
 ```php

--- a/README.md
+++ b/README.md
@@ -4994,7 +4994,7 @@ $persons->getDetailsOfAPerson($id);
 
 ### <a name="update_a_person"></a>![Method: ](https://apidocs.io/img/method.png ".PersonsController.updateAPerson") updateAPerson
 
-> Updates the properties of a person. For more information on how to update a person, see <a href="https://pipedrive.readme.io/docs/updating-a-person" target="_blank" rel="noopener noreferrer">this tutorial</a>.
+> Updates the properties of a person. Note that you can supply additional custom fields along with the request that are not described here. These custom fields are different for each Pipedrive account and can be recognized by long hashes as keys. To determine which custom fields exists, fetch the personFields and look for 'key' values. For more information on how to update a person, see <a href="https://pipedrive.readme.io/docs/updating-a-person" target="_blank" rel="noopener noreferrer">this tutorial</a>.
 
 
 ```php

--- a/src/Controllers/BaseController.php
+++ b/src/Controllers/BaseController.php
@@ -24,7 +24,7 @@ class BaseController
      * User-agent to be sent with API calls
      * @var string
      */
-    const USER_AGENT = 'Pipedrive-SDK-PHP-3.0.0';
+    const USER_AGENT = 'Pipedrive-SDK-PHP-3.0.1';
 
     /**
      * HttpCallBack instance associated with this controller

--- a/src/Controllers/DealsController.php
+++ b/src/Controllers/DealsController.php
@@ -571,7 +571,7 @@ class DealsController extends BaseController
         //prepare headers
         $_headers = array (
             'user-agent'    => BaseController::USER_AGENT,
-            'Accept'        => 'application/json',
+            'content-type'  => 'application/json; charset=utf-8',
             'Authorization' => sprintf('Bearer %1$s', Configuration::$oAuthToken->accessToken)
         );
 

--- a/src/Controllers/DealsController.php
+++ b/src/Controllers/DealsController.php
@@ -518,7 +518,12 @@ class DealsController extends BaseController
      * //pipedrive.readme.io/docs/updating-a-deal" target="_blank" rel="noopener noreferrer">this
      * tutorial</a>.
      *
-     * @param  array  $options    Array with all options for search
+     * Note that you can supply additional custom fields along with the request that are
+     * not described here. These custom fields are different for each Pipedrive account and can be
+     * recognized by long hashes as keys. To determine which custom fields exists, fetch the dealFields and
+     * look for 'key' values.
+     *
+     * @param array   $options                Array with all options for search
      * @param integer $options['id']          ID of the deal
      * @param string  $options['title']       (optional) Deal title
      * @param string  $options['value']       (optional) Value of the deal. If omitted, value will be set to 0.
@@ -556,9 +561,9 @@ class DealsController extends BaseController
         $_queryBuilder = '/deals/{id}';
 
         //process optional query parameters
-        $_queryBuilder = APIHelper::appendUrlWithTemplateParameters($_queryBuilder, array (
-            'id'          => $this->val($options, 'id'),
-            ));
+        $_queryBuilder = APIHelper::appendUrlWithTemplateParameters($_queryBuilder, array(
+            'id' => $this->val($options, 'id'),
+        ));
 
         //validate and preprocess url
         $_queryUrl = APIHelper::cleanUrl(Configuration::getBaseUri() . $_queryBuilder);
@@ -570,29 +575,14 @@ class DealsController extends BaseController
             'Authorization' => sprintf('Bearer %1$s', Configuration::$oAuthToken->accessToken)
         );
 
-        //prepare parameters
-        $_parameters = array (
-            'title'       => $this->val($options, 'title'),
-            'value'       => $this->val($options, 'value'),
-            'currency'    => $this->val($options, 'currency'),
-            'user_id'     => $this->val($options, 'userId'),
-            'person_id'   => $this->val($options, 'personId'),
-            'org_id'      => $this->val($options, 'orgId'),
-            'stage_id'    => $this->val($options, 'stageId'),
-            'status'    => APIHelper::prepareFormFields($this->val($options, 'status')),
-            'probability' => $this->val($options, 'probability'),
-            'lost_reason' => $this->val($options, 'lostReason'),
-            'visible_to' => APIHelper::prepareFormFields($this->val($options, 'visibleTo'))
-        );
-
         //call on-before Http callback
-        $_httpRequest = new HttpRequest(HttpMethod::PUT, $_headers, $_queryUrl, $_parameters);
+        $_httpRequest = new HttpRequest(HttpMethod::PUT, $_headers, $_queryUrl, $options);
         if ($this->getHttpCallBack() != null) {
             $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
         }
 
         //and invoke the API call request to fetch the response
-        $response = Request::put($_queryUrl, $_headers, Request\Body::Form($_parameters));
+        $response = Request::put($_queryUrl, $_headers, Request\Body::Json($options));
 
         $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
         $_httpContext = new HttpContext($_httpRequest, $_httpResponse);

--- a/src/Controllers/OrganizationsController.php
+++ b/src/Controllers/OrganizationsController.php
@@ -434,7 +434,7 @@ class OrganizationsController extends BaseController
         //prepare headers
         $_headers = array (
             'user-agent'    => BaseController::USER_AGENT,
-            'Accept'        => 'application/json',
+            'content-type'  => 'application/json; charset=utf-8',
             'Authorization' => sprintf('Bearer %1$s', Configuration::$oAuthToken->accessToken)
         );
 


### PR DESCRIPTION
Fixes #15, #23 and #47

Updated `updateAPerson`, `updateADeal` and `updateAnOrganization` methods to accept all input keys (including custom fields)

Testing:
* Install this branch: `composer require pipedrive/pipedrive:dev-GRAL-2200-person-optional-fields`
* Run the following script (try also with different keys/values like e-mail etc) with `php -f index.php` or similar:
```
<?php

require_once __DIR__.'/vendor/autoload.php';

// Client configuration
$apiToken = 'YOUR_TOKEN';

$client = new Pipedrive\Client(null, null, null, $apiToken); // First 3 parameters are for OAuth2

try {
    $dealOptions['id'] = YOUR_DEAL_ID;
    $dealOptions['YOUR_DEAL_CUSTOM_FIELD_KEY'] = 'test';

    $orgOptions['id'] = YOUR_ORGANIZATION_ID;
    $orgOptions['YOUR_ORG_CUSTOM_FIELD_KEY'] = 'beep';

    $personOptions['id'] = YOUR_PERSON_ID;
    $personOptions['YOUR_PERSON_CUSTOM_FIELD_KEY'] = 'boop';

    $response = $client->getDeals()->updateADeal($dealOptions);
    print_r($response);

    $response = $client->getPersons()->updateAPerson($personOptions);
    print_r($response);

    $response = $client->getOrganizations()->updateAnOrganization($orgOptions);
    print_r($response);
} catch (\Pipedrive\APIException $e) {
    echo $e;
}
```