### PR TITLE
GRAL-2356 Change GetDealsTimeline model to expect an array of results

### DIFF
--- a/src/Controllers/BaseController.php
+++ b/src/Controllers/BaseController.php
@@ -24,7 +24,7 @@ class BaseController
      * User-agent to be sent with API calls
      * @var string
      */
-    const USER_AGENT = 'Pipedrive-SDK-PHP-3.2.0';
+    const USER_AGENT = 'Pipedrive-SDK-PHP-3.3.1';
 
     /**
      * HttpCallBack instance associated with this controller

--- a/src/Controllers/BaseController.php
+++ b/src/Controllers/BaseController.php
@@ -24,7 +24,7 @@ class BaseController
      * User-agent to be sent with API calls
      * @var string
      */
-    const USER_AGENT = 'Pipedrive-SDK-PHP-3.3.1';
+    const USER_AGENT = 'Pipedrive-SDK-PHP-4.0.1';
 
     /**
      * HttpCallBack instance associated with this controller

--- a/src/Models/GetDealsTimeline.php
+++ b/src/Models/GetDealsTimeline.php
@@ -23,14 +23,14 @@ class GetDealsTimeline implements JsonSerializable
     /**
      * Open and won Deals grouped into periods by defined interval, amount and date-type dealField
      * (field_key)
-     * @var \Pipedrive\Models\Data25|null $data public property
+     * @var \Pipedrive\Models\Data25[]|null $data public property
      */
     public $data;
 
     /**
      * Constructor to set initial or default values of member properties
      * @param bool   $success Initialization value for $this->success
-     * @param Data25 $data    Initialization value for $this->data
+     * @param Data25[] $data    Initialization value for $this->data
      */
     public function __construct()
     {


### PR DESCRIPTION
This change fixes a bug where getDealsTimeline was not expecting the return of an array.

**How to test**
- Checkout this branch;
- Set up an app as instructed in the repo's readme, but add your local repo to compose and add this branch's contents as a dependency instead of pipedrive/pipedrive, or simply replace the contents of pipedrive/pipedrive in your app's vendor directory with this branch contents;
- Autoload a file with the code bellow to try it out, don't forget to replace the path to the autoload lib with one that works in your app, plus replace the value:
-  $apiToken with your Pipedrive API Token
Feel free to change the parameters as well, to match a search that will return multiple results from your Pipedrive account.
```php
<?php

require_once __DIR__.'/../vendor/autoload.php';

session_start();

// Client configuration
$apiToken = '<YOUR API TOKEN HERE>';

$client = new Pipedrive\Client(null, null, null, $apiToken); 

try {
    $params = [
        'startDate' => new DateTime('2019-01-01'),
        'interval' => 'quarter',
        'amount' => 5,
        'fieldKey' => 'add_time',
    ];

     echo '<div><h2>Get deals timeline</h2><div>';
     $response = $client->getDeals()->getDealsTimeline($params);

     echo '<pre>';
     var_dump(json_encode($response->data, JSON_PRETTY_PRINT));
     echo '</pre>';

} catch (\Pipedrive\APIException $e) {
    echo $e;
}
```