### PR TITLE
GRAL-2664 - Fix WebhooksController

### DIFF
--- a/src/Controllers/WebhooksController.php
+++ b/src/Controllers/WebhooksController.php
@@ -143,7 +143,8 @@ class WebhooksController extends BaseController
         $_headers = array (
             'user-agent'       => BaseController::USER_AGENT,
             'Accept'           => 'application/json',
-            'Authorization' => sprintf('Bearer %1$s', Configuration::$oAuthToken->accessToken)
+            'Authorization' => sprintf('Bearer %1$s', Configuration::$oAuthToken->accessToken),
+            'Content-Type' => 'application/json'
         );
 
         //prepare parameters
@@ -163,7 +164,7 @@ class WebhooksController extends BaseController
         }
 
         //and invoke the API call request to fetch the response
-        $response = Request::post($_queryUrl, $_headers, Request\Body::Form($_parameters));
+        $response = Request::post($_queryUrl, $_headers, Request\Body::json($_parameters));
 
         $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
         $_httpContext = new HttpContext($_httpRequest, $_httpResponse);
@@ -218,17 +219,18 @@ class WebhooksController extends BaseController
         $_headers = array (
             'user-agent'    => BaseController::USER_AGENT,
             'Accept'        => 'application/json',
-            'Authorization' => sprintf('Bearer %1$s', Configuration::$oAuthToken->accessToken)
+            'Authorization' => sprintf('Bearer %1$s', Configuration::$oAuthToken->accessToken),
+            'Content-Type' => 'application/json'
         );
 
         //call on-before Http callback
-        $_httpRequest = new HttpRequest(HttpMethod::DELETE, $_headers, $_queryUrl);
+        $_httpRequest = new HttpRequest(HttpMethod::DELETE, $_headers, $_queryUrl, );
         if ($this->getHttpCallBack() != null) {
             $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
         }
 
         //and invoke the API call request to fetch the response
-        $response = Request::delete($_queryUrl, $_headers);
+        $response = Request::delete($_queryUrl, $_headers, Request\Body::json(array()));
 
         $_httpResponse = new HttpResponse($response->code, $response->headers, $response->raw_body);
         $_httpContext = new HttpContext($_httpRequest, $_httpResponse);

--- a/src/Controllers/WebhooksController.php
+++ b/src/Controllers/WebhooksController.php
@@ -224,7 +224,7 @@ class WebhooksController extends BaseController
         );
 
         //call on-before Http callback
-        $_httpRequest = new HttpRequest(HttpMethod::DELETE, $_headers, $_queryUrl, );
+        $_httpRequest = new HttpRequest(HttpMethod::DELETE, $_headers, $_queryUrl);
         if ($this->getHttpCallBack() != null) {
             $this->getHttpCallBack()->callOnBeforeRequest($_httpRequest);
         }


### PR DESCRIPTION
### Jira

https://pipedrive.atlassian.net/browse/GRAL-2664

### Changes

- changed **createANewWebhook** and **deleteExistingWebhook** functions to use json format

### Test

you can create a Test.php file on root of the project then add the code below and run with -> `php Test.php` cmd

```php
<?php

require_once __DIR__.'/vendor/autoload.php';

session_start();

// Client configuration
$apiToken = 'apihere';

$client = new Pipedrive\Client(null, null, null, $apiToken); // First 3 parameters are for OAuth2

try {
    // $response = $client->getUsers()->getCurrentUserData();
    // var_dump($response);

    $webhooks = $client->getWebhooks();

    $subscriptionUrl = 'https://webhook.site/06c9f11a-a954-47f3-b4af-59c8c6cf325c';
    $collect['subscriptionUrl'] = $subscriptionUrl;

    
    $eventAction = 'added';
    $collect['eventAction'] = $eventAction;

    $eventObject = 'deal';
    $collect['eventObject'] = $eventObject;
    
    $userId = 10257710;
    $collect['userId'] = $userId;

    $httpAuthUser = '';
    $collect['httpAuthUser'] = $httpAuthUser;

    $httpAuthPassword = '';
    $collect['httpAuthPassword'] = $httpAuthPassword;

    // $whResult = $webhooks->createANewWebhook($collect);

    // $whResult = $webhooks->getAllWebhooks();
    
    // $whResult = $webhooks->deleteExistingWebhook(928517);
    
    var_dump($whResult);

} catch (\Pipedrive\APIException $e) {
    // echo $e;
}
```

### AC

you should be able to run both errors without getting FST_ERR_CTP_INVALID_MEDIA_TYPE error message.
