### PR TITLE
GRAL-2613 - Wrong void return type

### DIFF
--- a/src/Controllers/ActivitiesController.php
+++ b/src/Controllers/ActivitiesController.php
@@ -49,7 +49,7 @@ class ActivitiesController extends BaseController
      * Marks multiple activities as deleted.
      *
      * @param string $ids Comma-separated IDs that will be deleted
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteMultipleActivitiesInBulk(
@@ -118,7 +118,7 @@ class ActivitiesController extends BaseController
      *                                        to.
      * @param int      $options['done']       (optional) Whether the activity is done or not. 0 = Not done, 1 = Done.
      *                                        If omitted returns both Done and Not done activities.
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getAllActivitiesAssignedToAParticularUser(
@@ -200,7 +200,7 @@ class ActivitiesController extends BaseController
      * @param integer  $options['orgId']        (optional) ID of the organization this activity will be associated
      *                                          with
      * @param string   $options['note']         (optional) Note of the activity (HTML format)
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function addAnActivity(
@@ -264,7 +264,7 @@ class ActivitiesController extends BaseController
      * Deletes an activity.
      *
      * @param integer $id ID of the activity
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteAnActivity(
@@ -317,7 +317,7 @@ class ActivitiesController extends BaseController
      * Returns details of a specific activity.
      *
      * @param integer $id ID of the activity
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getDetailsOfAnActivity(
@@ -392,7 +392,7 @@ class ActivitiesController extends BaseController
      * @param integer  $options['orgId']        (optional) ID of the organization this activity will be associated
      *                                          with
      * @param string   $options['note']         (optional) Note of the activity (HTML format)
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function updateEditAnActivity(

--- a/src/Controllers/ActivityFieldsController.php
+++ b/src/Controllers/ActivityFieldsController.php
@@ -47,7 +47,7 @@ class ActivityFieldsController extends BaseController
     /**
      * Return list of all fields for activity
      *
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getAllFieldsForAnActivity()

--- a/src/Controllers/ActivityTypesController.php
+++ b/src/Controllers/ActivityTypesController.php
@@ -48,7 +48,7 @@ class ActivityTypesController extends BaseController
      * Marks multiple activity types as deleted.
      *
      * @param string $ids Comma-separated activity type IDs to delete
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteMultipleActivityTypesInBulk(
@@ -100,7 +100,7 @@ class ActivityTypesController extends BaseController
     /**
      * Returns all activity types
      *
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getAllActivityTypes()
@@ -152,7 +152,7 @@ class ActivityTypesController extends BaseController
      * @param string $options['iconKey']  Icon graphic to use for representing this activity type.
      * @param string $options['color']    (optional) A designated color for the activity type in 6-character HEX format
      *                                    (e.g. FFFFFF for white, 000000 for black).
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function addNewActivityType(
@@ -207,7 +207,7 @@ class ActivityTypesController extends BaseController
      * Marks an activity type as deleted.
      *
      * @param integer $id ID of the activity type
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteAnActivityType(
@@ -267,7 +267,7 @@ class ActivityTypesController extends BaseController
      *                                     format (e.g. FFFFFF for white, 000000 for black).
      * @param integer $options['orderNr']  (optional) An order number for this activity type. Order numbers should be
      *                                     used to order the types in the activity type selections.
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function updateEditActivityType(

--- a/src/Controllers/CallLogsController.php
+++ b/src/Controllers/CallLogsController.php
@@ -49,7 +49,7 @@ class CallLogsController extends BaseController
      * @param  array  $options    Array with all options for search
      * @param integer $options['limit']                 (optional) For pagination, the limit of entries to be returned
      * @param integer $options['start']                 (optional) For pagination, the position that represents the first result for the page
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getAllCallLogsAssignedToAParticularUser(
@@ -230,7 +230,7 @@ class CallLogsController extends BaseController
      * @param  array  $options    Array with all options for search
      * @param string  $options['file']        Audio file supported by the HTML5 specification
      * @param string  $options['mime_type']        The MIME type of the audio file supported by the HTML5 specification
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function attachAnAudioFileToTheCallLog(

--- a/src/Controllers/DealFieldsController.php
+++ b/src/Controllers/DealFieldsController.php
@@ -48,7 +48,7 @@ class DealFieldsController extends BaseController
      * Marks multiple fields as deleted.
      *
      * @param string $ids Comma-separated field IDs to delete
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteMultipleDealFieldsInBulk(
@@ -103,7 +103,7 @@ class DealFieldsController extends BaseController
      * @param  array  $options    Array with all options for search
      * @param integer $options['start'] (optional) Pagination start
      * @param integer $options['limit'] (optional) Items shown per page
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getAllDealFields(
@@ -159,7 +159,7 @@ class DealFieldsController extends BaseController
      * tutorial</a>.
      *
      * @param object $body (optional) TODO: type description here
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function addANewDealField(
@@ -213,7 +213,7 @@ class DealFieldsController extends BaseController
      * tutorial</a>.
      *
      * @param integer $id ID of the field
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteADealField(
@@ -266,7 +266,7 @@ class DealFieldsController extends BaseController
      * Returns data about a specific deal field.
      *
      * @param integer $id ID of the field
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getOneDealField(
@@ -326,7 +326,7 @@ class DealFieldsController extends BaseController
      * @param string  $options['options'] (optional) When field_type is either set or enum, possible options must be
      *                                    supplied as a JSON-encoded sequential array, for example: ["red","blue",
      *                                    "lilac"]
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function updateADealField(

--- a/src/Controllers/DealsController.php
+++ b/src/Controllers/DealsController.php
@@ -606,7 +606,7 @@ class DealsController extends BaseController
      * @param int     $options['done']    (optional) Whether the activity is done or not. 0 = Not done, 1 = Done. If
      *                                    omitted returns both Done and Not done activities.
      * @param string  $options['exclude'] (optional) A comma-separated string of activity IDs to exclude from result
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listActivitiesAssociatedWithADeal(
@@ -734,7 +734,7 @@ class DealsController extends BaseController
      *                                                  keys are supported (no nested keys). Supported fields: id,
      *                                                  user_id, deal_id, person_id, org_id, product_id, add_time,
      *                                                  update_time, file_name, file_type, file_size, comment.
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listFilesAttachedToADeal(
@@ -798,7 +798,7 @@ class DealsController extends BaseController
      * @param integer $options['id']    ID of the deal
      * @param integer $options['start'] (optional) Pagination start
      * @param integer $options['limit'] (optional) Items shown per page
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listUpdatesAboutADeal(
@@ -857,7 +857,7 @@ class DealsController extends BaseController
      * Lists the followers of a deal.
      *
      * @param integer $id ID of the deal
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listFollowersOfADeal(
@@ -1035,7 +1035,7 @@ class DealsController extends BaseController
      * @param integer $options['id']    ID of the deal
      * @param integer $options['start'] (optional) Pagination start
      * @param integer $options['limit'] (optional) Items shown per page
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listMailMessagesAssociatedWithADeal(
@@ -1162,7 +1162,7 @@ class DealsController extends BaseController
      * @param integer $options['id']    ID of the deal
      * @param integer $options['start'] (optional) Pagination start
      * @param integer $options['limit'] (optional) Items shown per page
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listParticipantsOfADeal(
@@ -1223,7 +1223,7 @@ class DealsController extends BaseController
      * @param  array  $options    Array with all options for search
      * @param integer $options['id']        ID of the deal
      * @param integer $options['personId']  ID of the person
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function addAParticipantToADeal(
@@ -1340,7 +1340,7 @@ class DealsController extends BaseController
      * List users permitted to access a deal
      *
      * @param integer $id ID of the deal
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listPermittedUsers(
@@ -1397,7 +1397,7 @@ class DealsController extends BaseController
      * @param integer $options['id']    ID of the deal
      * @param integer $options['start'] (optional) Pagination start
      * @param integer $options['limit'] (optional) Items shown per page
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listAllPersonsAssociatedWithADeal(
@@ -1461,7 +1461,7 @@ class DealsController extends BaseController
      * @param integer $options['limit']                (optional) Items shown per page
      * @param int     $options['includeProductData']   (optional) Whether to fetch product data along with each
      *                                                 attached product (1) or not (0, default).
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listProductsAttachedToADeal(
@@ -1741,7 +1741,7 @@ class DealsController extends BaseController
      * @param integer $options['start']       (optional) Pagination start. Note that the pagination is based on main results and does not include related items when using search_for_related_items parameter.
      * @param integer $options['limit']       (optional) Items shown per page
      *
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function searchDeals(

--- a/src/Controllers/FilesController.php
+++ b/src/Controllers/FilesController.php
@@ -58,7 +58,7 @@ class FilesController extends BaseController
      *                                                  keys are supported (no nested keys). Supported fields: id,
      *                                                  user_id, deal_id, person_id, org_id, product_id, add_time,
      *                                                  update_time, file_name, file_type, file_size, comment.
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getAllFiles(
@@ -124,7 +124,7 @@ class FilesController extends BaseController
      * @param integer $options['productId']   (optional) ID of the product to associate file(s) with
      * @param integer $options['activityId']  (optional) ID of the activity to associate file(s) with
      * @param integer $options['noteId']      (optional) ID of the note to associate file(s) with
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function addFile(
@@ -191,7 +191,7 @@ class FilesController extends BaseController
      * @param integer $options['itemId']          ID of the item to associate the file with
      * @param string  $options['remoteLocation']  The location type to send the file to. Only googledrive is supported
      *                                            at the moment.
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function createARemoteFileAndLinkItToAnItem(
@@ -255,7 +255,7 @@ class FilesController extends BaseController
      * @param string  $options['remoteId']        The remote item id
      * @param string  $options['remoteLocation']  The location type to send the file to. Only googledrive is supported
      *                                            at the moment.
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function createLinkARemoteFileToAnItem(
@@ -311,7 +311,7 @@ class FilesController extends BaseController
      * Marks a file as deleted.
      *
      * @param integer $id ID of the file
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteAFile(
@@ -364,7 +364,7 @@ class FilesController extends BaseController
      * Returns data about a specific file.
      *
      * @param integer $id ID of the file
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getOneFile(
@@ -420,7 +420,7 @@ class FilesController extends BaseController
      * @param integer $options['id']          ID of the file
      * @param string  $options['name']        (optional) Visible name of the file
      * @param string  $options['description'] (optional) Description of the file
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function updateFileDetails(
@@ -479,7 +479,7 @@ class FilesController extends BaseController
      * Initializes a file download.
      *
      * @param integer $id ID of the file
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getDownloadOneFile(

--- a/src/Controllers/FiltersController.php
+++ b/src/Controllers/FiltersController.php
@@ -48,7 +48,7 @@ class FiltersController extends BaseController
      * Marks multiple filters as deleted.
      *
      * @param string $ids Comma-separated filter IDs to delete
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteMultipleFiltersInBulk(
@@ -101,7 +101,7 @@ class FiltersController extends BaseController
      * Returns data about all filters
      *
      * @param string $type (optional) Types of filters to fetch
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getAllFilters(
@@ -174,7 +174,7 @@ class FiltersController extends BaseController
      *                                      LIKE '%$'". To get a better understanding of how filters work try creating
      *                                      them directly from the Pipedrive application.
      * @param string $options['type']       Type of filter to create.
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function addANewFilter(
@@ -232,7 +232,7 @@ class FiltersController extends BaseController
      * used, see <a href="https://pipedrive.readme.io/docs/adding-a-filter" target="_blank" rel="noopener
      * noreferrer">this tutorial</a>.
      *
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getAllFilterHelpers()
@@ -279,7 +279,7 @@ class FiltersController extends BaseController
      * Marks a filter as deleted.
      *
      * @param integer $id ID of the filter
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteAFilter(
@@ -332,7 +332,7 @@ class FiltersController extends BaseController
      * Returns data about a specific filter. Note that this also returns the condition lines of the filter.
      *
      * @param integer $id ID of the filter
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getOneFilter(
@@ -400,7 +400,7 @@ class FiltersController extends BaseController
      *                                       LIKE '%$'". To get a better understanding of how filters work try creating
      *                                       them directly from the Pipedrive application.
      * @param string  $options['name']       (optional) Filter name
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function updateFilter(

--- a/src/Controllers/GoalsController.php
+++ b/src/Controllers/GoalsController.php
@@ -49,7 +49,7 @@ class GoalsController extends BaseController
      * Adds a new goal.
      *
      * @param object $body (optional) TODO: type description here
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function addANewGoal(
@@ -138,7 +138,7 @@ class GoalsController extends BaseController
      *                                                              provided too.
      * @param DateTime $options['periodEnd']                        (optional) End date of the period for which to find
      *                                                              goals. Date in format of YYYY-MM-DD.
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function findGoals(
@@ -229,7 +229,7 @@ class GoalsController extends BaseController
      * @param string $options['interval']         (optional) Date when the goal starts and ends. It requires the
      *                                            following JSON structure: { "start": "2019-01-01", "end": "2022-12-
      *                                            31" }. Date in format of YYYY-MM-DD.
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function updateExistingGoal(
@@ -292,7 +292,7 @@ class GoalsController extends BaseController
      * Marks goal as deleted.
      *
      * @param string $id ID of the goal to be deleted.
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteExistingGoal(
@@ -350,7 +350,7 @@ class GoalsController extends BaseController
      *                                          format of YYYY-MM-DD.
      * @param DateTime $options['periodEnd']    End date of the period for which to find progress of a goal. Date in
      *                                          format of YYYY-MM-DD.
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getResultOfAGoal(

--- a/src/Controllers/ItemSearchController.php
+++ b/src/Controllers/ItemSearchController.php
@@ -58,7 +58,7 @@ class ItemSearchController extends BaseController
      * @param integer $options['start']       (optional) Pagination start. Note that the pagination is based on main results and does not include related items when using search_for_related_items parameter.
      * @param integer $options['limit']       (optional) Items shown per page
      *
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function performASearchFromMultipleItemTypes(
@@ -126,7 +126,7 @@ class ItemSearchController extends BaseController
      * @param integer $options['start']       (optional) Pagination start
      * @param integer $options['limit']       (optional) Items shown per page
      *
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function performASearchUsingASpecificFieldFromAnItemType(

--- a/src/Controllers/NoteFieldsController.php
+++ b/src/Controllers/NoteFieldsController.php
@@ -47,7 +47,7 @@ class NoteFieldsController extends BaseController
     /**
      * Return list of all fields for note
      *
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getAllFieldsForANote()

--- a/src/Controllers/OrganizationFieldsController.php
+++ b/src/Controllers/OrganizationFieldsController.php
@@ -48,7 +48,7 @@ class OrganizationFieldsController extends BaseController
      * Marks multiple fields as deleted.
      *
      * @param string $ids Comma-separated field IDs to delete
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteMultipleOrganizationFieldsInBulk(
@@ -100,7 +100,7 @@ class OrganizationFieldsController extends BaseController
     /**
      * Returns data about all organization fields
      *
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getAllOrganizationFields()
@@ -149,7 +149,7 @@ class OrganizationFieldsController extends BaseController
      * tutorial</a>.
      *
      * @param object $body (optional) TODO: type description here
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function addANewOrganizationField(
@@ -203,7 +203,7 @@ class OrganizationFieldsController extends BaseController
      * tutorial</a>.
      *
      * @param integer $id ID of the field
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteAnOrganizationField(
@@ -256,7 +256,7 @@ class OrganizationFieldsController extends BaseController
      * Returns data about a specific organization field.
      *
      * @param integer $id ID of the field
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getOneOrganizationField(
@@ -318,7 +318,7 @@ class OrganizationFieldsController extends BaseController
      *                                    be supplied and already existing items must have their ID supplied. New items
      *                                    only require a label. Example: [{"id":123,"label":"Existing Item"},{"label":
      *                                    "New Item"}]
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function updateAnOrganizationField(

--- a/src/Controllers/OrganizationRelationshipsController.php
+++ b/src/Controllers/OrganizationRelationshipsController.php
@@ -48,7 +48,7 @@ class OrganizationRelationshipsController extends BaseController
      * Gets all of the relationships for a supplied organization id.
      *
      * @param integer $orgId  ID of the organization to get relationships for
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getAllRelationshipsForOrganization(
@@ -101,7 +101,7 @@ class OrganizationRelationshipsController extends BaseController
      * Creates and returns an organization relationship.
      *
      * @param object $body (optional) TODO: type description here
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function createAnOrganizationRelationship(
@@ -153,7 +153,7 @@ class OrganizationRelationshipsController extends BaseController
      * Deletes an organization relationship and returns the deleted id.
      *
      * @param integer $id ID of the organization relationship
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteAnOrganizationRelationship(
@@ -208,7 +208,7 @@ class OrganizationRelationshipsController extends BaseController
      * @param  array  $options    Array with all options for search
      * @param integer $options['id']     ID of the organization relationship
      * @param integer $options['orgId']  (optional) ID of the base organization for the returned calculated values
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getOneOrganizationRelationship(
@@ -275,7 +275,7 @@ class OrganizationRelationshipsController extends BaseController
      *                                              daughter.
      * @param integer $options['relLinkedOrgId']    (optional) The linked organization in this relationship. If type is
      *                                              'parent', then the linked organization is the daughter.
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function updateAnOrganizationRelationship(

--- a/src/Controllers/OrganizationsController.php
+++ b/src/Controllers/OrganizationsController.php
@@ -48,7 +48,7 @@ class OrganizationsController extends BaseController
      * Marks multiple organizations as deleted.
      *
      * @param string $ids Comma-separated IDs that will be deleted
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteMultipleOrganizationsInBulk(
@@ -111,7 +111,7 @@ class OrganizationsController extends BaseController
      * @param string  $options['sort']       (optional) Field names and sorting mode separated by a comma (field_name_1
      *                                       ASC, field_name_2 DESC). Only first-level field keys are supported (no
      *                                       nested keys).
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getAllOrganizations(
@@ -176,7 +176,7 @@ class OrganizationsController extends BaseController
      * @param integer $options['start']       (optional) Pagination start. Note that the pagination is based on main results and does not include related items when using search_for_related_items parameter.
      * @param integer $options['limit']       (optional) Items shown per page
      *
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function searchOrganizations(
@@ -238,7 +238,7 @@ class OrganizationsController extends BaseController
      * noreferrer">this tutorial</a>.
      *
      * @param object $body (optional) TODO: type description here
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function addAnOrganization(
@@ -290,7 +290,7 @@ class OrganizationsController extends BaseController
      * Marks an organization as deleted.
      *
      * @param integer $id ID of the organization
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteAnOrganization(
@@ -345,7 +345,7 @@ class OrganizationsController extends BaseController
      * resulting data. These hashes can be mapped against the 'key' value of organizationFields.
      *
      * @param integer $id ID of the organization
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getDetailsOfAnOrganization(
@@ -471,7 +471,7 @@ class OrganizationsController extends BaseController
      * @param int     $options['done']    (optional) Whether the activity is done or not. 0 = Not done, 1 = Done. If
      *                                    omitted returns both Done and Not done activities.
      * @param string  $options['exclude'] (optional) A comma-separated string of activity IDs to exclude from result
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listActivitiesAssociatedWithAnOrganization(
@@ -546,7 +546,7 @@ class OrganizationsController extends BaseController
      *                                                     related to the organization. Indirect relations include
      *                                                     relations through custom, organization-type fields and
      *                                                     through persons of the given organization.
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listDealsAssociatedWithAnOrganization(
@@ -619,7 +619,7 @@ class OrganizationsController extends BaseController
      *                                                  keys are supported (no nested keys). Supported fields: id,
      *                                                  user_id, deal_id, person_id, org_id, product_id, add_time,
      *                                                  update_time, file_name, file_type, file_size, comment.
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listFilesAttachedToAnOrganization(
@@ -683,7 +683,7 @@ class OrganizationsController extends BaseController
      * @param integer $options['id']    ID of the organization
      * @param integer $options['start'] (optional) Pagination start
      * @param integer $options['limit'] (optional) Items shown per page
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listUpdatesAboutAnOrganization(
@@ -742,7 +742,7 @@ class OrganizationsController extends BaseController
      * Lists the followers of an organization.
      *
      * @param integer $id ID of the organization
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listFollowersOfAnOrganization(
@@ -797,7 +797,7 @@ class OrganizationsController extends BaseController
      * @param  array  $options    Array with all options for search
      * @param integer $options['id']      ID of the organization
      * @param integer $options['userId']  ID of the user
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function addAFollowerToAnOrganization(
@@ -859,7 +859,7 @@ class OrganizationsController extends BaseController
      * @param  array  $options    Array with all options for search
      * @param integer $options['id']          ID of the organization
      * @param integer $options['followerId']  ID of the follower
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteAFollowerFromAnOrganization(
@@ -916,7 +916,7 @@ class OrganizationsController extends BaseController
      * @param integer $options['id']    ID of the organization
      * @param integer $options['start'] (optional) Pagination start
      * @param integer $options['limit'] (optional) Items shown per page
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listMailMessagesAssociatedWithAnOrganization(
@@ -979,7 +979,7 @@ class OrganizationsController extends BaseController
      * @param  array  $options    Array with all options for search
      * @param integer $options['id']            ID of the organization
      * @param integer $options['mergeWithId']   ID of the organization that the organization will be merged with
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function updateMergeTwoOrganizations(
@@ -1037,7 +1037,7 @@ class OrganizationsController extends BaseController
      * List users permitted to access an organization
      *
      * @param integer $id ID of the organization
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listPermittedUsers(
@@ -1093,7 +1093,7 @@ class OrganizationsController extends BaseController
      * @param integer $options['id']    ID of the organization
      * @param integer $options['start'] (optional) Pagination start
      * @param integer $options['limit'] (optional) Items shown per page
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listPersonsOfAnOrganization(

--- a/src/Controllers/PersonFieldsController.php
+++ b/src/Controllers/PersonFieldsController.php
@@ -48,7 +48,7 @@ class PersonFieldsController extends BaseController
      * Marks multiple fields as deleted.
      *
      * @param string $ids Comma-separated field IDs to delete
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteMultiplePersonFieldsInBulk(
@@ -100,7 +100,7 @@ class PersonFieldsController extends BaseController
     /**
      * Returns data about all person fields
      *
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getAllPersonFields()
@@ -149,7 +149,7 @@ class PersonFieldsController extends BaseController
      * tutorial</a>.
      *
      * @param object $body (optional) TODO: type description here
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function addANewPersonField(
@@ -203,7 +203,7 @@ class PersonFieldsController extends BaseController
      * tutorial</a>.
      *
      * @param integer $id ID of the field
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteAPersonField(
@@ -256,7 +256,7 @@ class PersonFieldsController extends BaseController
      * Returns data about a specific person field.
      *
      * @param integer $id ID of the field
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getOnePersonField(
@@ -318,7 +318,7 @@ class PersonFieldsController extends BaseController
      *                                    be supplied and already existing items must have their ID supplied. New items
      *                                    only require a label. Example: [{"id":123,"label":"Existing Item"},{"label":
      *                                    "New Item"}]
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function updateAPersonField(

--- a/src/Controllers/PersonsController.php
+++ b/src/Controllers/PersonsController.php
@@ -48,7 +48,7 @@ class PersonsController extends BaseController
      * Marks multiple persons as deleted.
      *
      * @param string $ids (optional) Comma-separated IDs that will be deleted
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteMultiplePersonsInBulk(
@@ -112,7 +112,7 @@ class PersonsController extends BaseController
      * @param string  $options['sort']       (optional) Field names and sorting mode separated by a comma (field_name_1
      *                                       ASC, field_name_2 DESC). Only first-level field keys are supported (no
      *                                       nested keys).
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getAllPersons(
@@ -178,7 +178,7 @@ class PersonsController extends BaseController
      * @param integer $options['start']       (optional) Pagination start. Note that the pagination is based on main results and does not include related items when using search_for_related_items parameter.
      * @param integer $options['limit']       (optional) Items shown per page
      *
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function searchPersons(
@@ -240,7 +240,7 @@ class PersonsController extends BaseController
      * and look for 'key' values.
      *
      * @param object $body (optional) TODO: type description here
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function addAPerson(
@@ -292,7 +292,7 @@ class PersonsController extends BaseController
      * Marks a person as deleted.
      *
      * @param integer $id ID of a person
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteAPerson(
@@ -347,7 +347,7 @@ class PersonsController extends BaseController
      * resulting data. These hashes can be mapped against the 'key' value of personFields.
      *
      * @param integer $id ID of a person
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getDetailsOfAPerson(
@@ -420,7 +420,7 @@ class PersonsController extends BaseController
      *                                       the default visibility setting of this item type for the authorized user.
      *                                       <dl class="fields-list"><dt>1</dt><dd>Owner &amp; followers
      *                                       (private)</dd><dt>3</dt><dd>Entire company (shared)</dd></dl>
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function updateAPerson(
@@ -480,7 +480,7 @@ class PersonsController extends BaseController
      * @param int     $options['done']    (optional) Whether the activity is done or not. 0 = Not done, 1 = Done. If
      *                                    omitted returns both Done and Not done activities.
      * @param string  $options['exclude'] (optional) A comma-separated string of activity IDs to exclude from result
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listActivitiesAssociatedWithAPerson(
@@ -549,7 +549,7 @@ class PersonsController extends BaseController
      * @param string  $options['sort']   (optional) Field names and sorting mode separated by a comma (field_name_1 ASC,
      *                                   field_name_2 DESC). Only first-level field keys are supported (no nested
      *                                   keys).
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listDealsAssociatedWithAPerson(
@@ -621,7 +621,7 @@ class PersonsController extends BaseController
      *                                                  keys are supported (no nested keys). Supported fields: id,
      *                                                  user_id, deal_id, person_id, org_id, product_id, add_time,
      *                                                  update_time, file_name, file_type, file_size, comment.
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listFilesAttachedToAPerson(
@@ -685,7 +685,7 @@ class PersonsController extends BaseController
      * @param integer $options['id']    ID of a person
      * @param integer $options['start'] (optional) Pagination start
      * @param integer $options['limit'] (optional) Items shown per page
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listUpdatesAboutAPerson(
@@ -744,7 +744,7 @@ class PersonsController extends BaseController
      * Lists the followers of a person.
      *
      * @param integer $id ID of a person
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listFollowersOfAPerson(
@@ -799,7 +799,7 @@ class PersonsController extends BaseController
      * @param  array  $options    Array with all options for search
      * @param integer $options['id']      ID of a person
      * @param integer $options['userId']  ID of the user
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function addAFollowerToAPerson(
@@ -859,7 +859,7 @@ class PersonsController extends BaseController
      * @param  array  $options    Array with all options for search
      * @param integer $options['id']          ID of a person
      * @param integer $options['followerId']  ID of the follower
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deletesAFollowerFromAPerson(
@@ -916,7 +916,7 @@ class PersonsController extends BaseController
      * @param integer $options['id']    ID of a person
      * @param integer $options['start'] (optional) Pagination start
      * @param integer $options['limit'] (optional) Items shown per page
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listMailMessagesAssociatedWithAPerson(
@@ -979,7 +979,7 @@ class PersonsController extends BaseController
      * @param  array  $options    Array with all options for search
      * @param integer $options['id']            ID of a person
      * @param integer $options['mergeWithId']   ID of the person that the person will be merged with
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function updateMergeTwoPersons(
@@ -1037,7 +1037,7 @@ class PersonsController extends BaseController
      * List users permitted to access a person
      *
      * @param integer $id ID of a person
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listPermittedUsers(
@@ -1090,7 +1090,7 @@ class PersonsController extends BaseController
      * Delete person picture
      *
      * @param integer $id ID of a person
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deletePersonPicture(
@@ -1152,7 +1152,7 @@ class PersonsController extends BaseController
      * @param integer $options['cropY']       (optional) Y coordinate to where start cropping form (in pixels)
      * @param integer $options['cropWidth']   (optional) Width of cropping area (in pixels)
      * @param integer $options['cropHeight']  (optional) Height of cropping area (in pixels)
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function addPersonPicture(
@@ -1217,7 +1217,7 @@ class PersonsController extends BaseController
      * @param integer $options['id']    ID of a person
      * @param integer $options['start'] (optional) Pagination start
      * @param integer $options['limit'] (optional) Items shown per page
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listProductsAssociatedWithAPerson(

--- a/src/Controllers/PipelinesController.php
+++ b/src/Controllers/PipelinesController.php
@@ -48,7 +48,7 @@ class PipelinesController extends BaseController
     /**
      * Returns data about all pipelines
      *
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getAllPipelines()
@@ -100,7 +100,7 @@ class PipelinesController extends BaseController
      * @param integer $options['orderNr']          (optional) Defines pipelines order. First order(order_nr=0) is the
      *                                             default pipeline.
      * @param int     $options['active']           (optional) TODO: type description here
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function addANewPipeline(
@@ -156,7 +156,7 @@ class PipelinesController extends BaseController
      * Marks a pipeline as deleted.
      *
      * @param integer $id ID of the pipeline
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteAPipeline(
@@ -217,7 +217,7 @@ class PipelinesController extends BaseController
      *                                                    amounts in the given currency per each stage. You may also
      *                                                    set this parameter to 'default_currency' in which case users
      *                                                    default currency is used.
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getOnePipeline(
@@ -281,7 +281,7 @@ class PipelinesController extends BaseController
      * @param integer $options['orderNr']          (optional) Defines pipelines order. First order(order_nr=0) is the
      *                                             default pipeline.
      * @param int     $options['active']           (optional) TODO: type description here
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function updateEditAPipeline(
@@ -347,7 +347,7 @@ class PipelinesController extends BaseController
      * @param DateTime $options['endDate']    End of the period. Date in format of YYYY-MM-DD.
      * @param integer  $options['userId']     (optional) ID of the user who's pipeline metrics statistics to fetch. If
      *                                        omitted, the authorized user will be used.
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getDealsConversionRatesInPipeline(
@@ -429,7 +429,7 @@ class PipelinesController extends BaseController
      *                                                    per each stage. You may also set this parameter to
      *                                                    'default_currency' in which case users default currency is
      *                                                    used. Only works when get_summary parameter flag is enabled.
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getDealsInAPipeline(
@@ -499,7 +499,7 @@ class PipelinesController extends BaseController
      * @param DateTime $options['endDate']    End of the period. Date in format of YYYY-MM-DD.
      * @param integer  $options['userId']     (optional) ID of the user who's pipeline statistics to fetch. If omitted,
      *                                        the authorized user will be used.
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getDealsMovementsInPipeline(

--- a/src/Controllers/ProductsController.php
+++ b/src/Controllers/ProductsController.php
@@ -121,7 +121,7 @@ class ProductsController extends BaseController
      * @param integer $options['start']       (optional) Pagination start. Note that the pagination is based on main results and does not include related items when using search_for_related_items parameter.
      * @param integer $options['limit']       (optional) Items shown per page
      *
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function searchProducts(
@@ -181,7 +181,7 @@ class ProductsController extends BaseController
      * noreferrer">this tutorial</a>.
      *
      * @param object $body (optional) TODO: type description here
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function addAProduct(
@@ -233,7 +233,7 @@ class ProductsController extends BaseController
      * Marks a product as deleted.
      *
      * @param integer $id ID of the product
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteAProduct(
@@ -286,7 +286,7 @@ class ProductsController extends BaseController
      * Returns data about a specific product.
      *
      * @param integer $id ID of the product
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getOneProduct(
@@ -489,7 +489,7 @@ class ProductsController extends BaseController
      *                                                  keys are supported (no nested keys). Supported fields: id,
      *                                                  user_id, deal_id, person_id, org_id, product_id, add_time,
      *                                                  update_time, file_name, file_type, file_size, comment.
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listFilesAttachedToAProduct(

--- a/src/Controllers/RecentsController.php
+++ b/src/Controllers/RecentsController.php
@@ -53,7 +53,7 @@ class RecentsController extends BaseController
      *                                            (optional)
      * @param integer $options['start']           (optional) Pagination start
      * @param integer $options['limit']           (optional) Items shown per page
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getRecents(

--- a/src/Controllers/StagesController.php
+++ b/src/Controllers/StagesController.php
@@ -48,7 +48,7 @@ class StagesController extends BaseController
      * Marks multiple stages as deleted.
      *
      * @param string $ids Comma-separated stage IDs to delete
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteMultipleStagesInBulk(
@@ -102,7 +102,7 @@ class StagesController extends BaseController
      *
      * @param integer $pipelineId  (optional) ID of the pipeline to fetch stages for. If omitted, stages for all
      *                             pipelines will be fetched.
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getAllStages(
@@ -155,7 +155,7 @@ class StagesController extends BaseController
      * Adds a new stage, returns the ID upon success.
      *
      * @param object $body (optional) TODO: type description here
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function addANewStage(
@@ -207,7 +207,7 @@ class StagesController extends BaseController
      * Marks a stage as deleted.
      *
      * @param integer $id ID of the stage
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteAStage(
@@ -260,7 +260,7 @@ class StagesController extends BaseController
      * Returns data about a specific stage
      *
      * @param integer $id ID of the stage
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getOneStage(
@@ -315,7 +315,7 @@ class StagesController extends BaseController
      * @param  array  $options    Array with all options for search
      * @param integer $options['id']   ID of the stage
      * @param object  $options['body'] (optional) TODO: type description here
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function updateStageDetails(
@@ -382,7 +382,7 @@ class StagesController extends BaseController
      *                                      instead, deals owned by everyone will be returned.
      * @param integer $options['start']     (optional) Pagination start
      * @param integer $options['limit']     (optional) Items shown per page
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getDealsInAStage(

--- a/src/Controllers/UserSettingsController.php
+++ b/src/Controllers/UserSettingsController.php
@@ -47,7 +47,7 @@ class UserSettingsController extends BaseController
     /**
      * Lists settings of authorized user.
      *
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listSettingsOfAuthorizedUser()

--- a/src/Controllers/UsersController.php
+++ b/src/Controllers/UsersController.php
@@ -421,7 +421,7 @@ class UsersController extends BaseController
      * synced in to Pipedrive when using the built-in Mailbox.
      *
      * @param integer $id ID of the user
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listBlacklistedEmailAddressesOfAUser(
@@ -477,7 +477,7 @@ class UsersController extends BaseController
      * @param integer $options['id']      ID of the user
      * @param string  $options['address'] Email address to blacklist (can contain \\* for wildcards, e.g. \\*@example.
      *                                    com, or john\\*@ex\\*.com)
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function addBlacklistedEmailAddressForAUser(
@@ -596,7 +596,7 @@ class UsersController extends BaseController
      * List aggregated permissions over all assigned permission sets for a user
      *
      * @param integer $id ID of the user
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listUserPermissions(
@@ -651,7 +651,7 @@ class UsersController extends BaseController
      * @param  array  $options    Array with all options for search
      * @param integer $options['id']      ID of the user
      * @param integer $options['roleId']  ID of the role
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function deleteARoleAssignment(
@@ -712,7 +712,7 @@ class UsersController extends BaseController
      * @param integer $options['id']    ID of the user
      * @param integer $options['start'] (optional) Pagination start
      * @param integer $options['limit'] (optional) Items shown per page
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listRoleAssignments(
@@ -773,7 +773,7 @@ class UsersController extends BaseController
      * @param  array  $options    Array with all options for search
      * @param integer $options['id']      ID of the user
      * @param integer $options['roleId']  ID of the role
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function addRoleAssignment(
@@ -831,7 +831,7 @@ class UsersController extends BaseController
      * List settings of user's assigned role
      *
      * @param integer $id ID of the user
-     * @return void response from the API call
+     * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function listUserRoleSettings(


### PR DESCRIPTION
### Jira
https://pipedrive.atlassian.net/browse/GRAL-2613

### Changes
- Every place where the API returns a JsonSerializer we should return type \Pipedrive\Utils\JsonSerializer instead of void.

From:
<img width="680" alt="image" src="https://user-images.githubusercontent.com/461342/156002036-c617a0cb-f561-4c29-a9d4-09c32d6e0f7f.png">

To:
<img width="698" alt="image" src="https://user-images.githubusercontent.com/461342/156001880-cdd7efc8-2d01-472a-9221-92e5e3352a97.png">
