### PR TITLE
Ignore dev/testing files for distribution builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # Ignore dev/testing files for distribution builds
 /tests export-ignore
-CODEOWNERS export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 phpunit.xml export-ignore
+CODEOWNERS export-ignore
+repository.json export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Ignore dev/testing files for distribution builds
+/tests export-ignore
+CODEOWNERS export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml export-ignore


### PR DESCRIPTION
`.gitattributes` file was missing from the `client-php`.
It's actually a good idea to exclude unneeded dev files from the the production archive, which is used by composer for instance.

The files I mentioned are only useful when working on the library itself.

If you are not familiar with `.gitattributes`/`export-ignore`, you can find further info below:
- http://www.pixelite.co.nz/article/using-git-attributes-exclude-files-your-release/


I hope it helps! 🙂