### PR TITLE
GRAL-3076 Added pagination support to getAllPersonFields

### DIFF
--- a/README.md
+++ b/README.md
@@ -4852,15 +4852,24 @@ $personFields->deleteMultiplePersonFieldsInBulk($ids);
 ```php
 function getAllPersonFields()
 ```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| start |  ``` Optional ```  ``` DefaultValue ```  | Pagination start     |
+| limit |  ``` Optional ``` | Items shown per page |
 
 #### Example Usage
 
 ```php
+$start = 0;
+$collect['start'] = $start;
 
-$personFields->getAllPersonFields();
+$limit = 69;
+$collect['limit'] = $limit;
 
+$personFields->getAllPersonFields($collect);
 ```
-
 
 ### <a name="add_a_new_person_field"></a>![Method: ](https://apidocs.io/img/method.png ".PersonFieldsController.addANewPersonField") addANewPersonField
 

--- a/src/Controllers/BaseController.php
+++ b/src/Controllers/BaseController.php
@@ -24,7 +24,7 @@ class BaseController
      * User-agent to be sent with API calls
      * @var string
      */
-    const USER_AGENT = 'Pipedrive-SDK-PHP-4.0.0';
+    const USER_AGENT = 'Pipedrive-SDK-PHP-4.0.3';
 
     /**
      * HttpCallBack instance associated with this controller

--- a/src/Controllers/PersonFieldsController.php
+++ b/src/Controllers/PersonFieldsController.php
@@ -103,13 +103,20 @@ class PersonFieldsController extends BaseController
      * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
-    public function getAllPersonFields()
-    {
+    public function getAllPersonFields(
+        $options
+    ) {
         //check or get oauth token
         OAuthManager::getInstance()->checkAuthorization();
 
         //prepare query string for API call
         $_queryBuilder = '/personFields';
+
+        //process optional query parameters
+        APIHelper::appendUrlWithQueryParameters($_queryBuilder, array (
+            'start'      => $this->val($options, 'start', 0),
+            'limit'      => $this->val($options, 'limit'),
+        ));
 
         //validate and preprocess url
         $_queryUrl = APIHelper::cleanUrl(Configuration::getBaseUri() . $_queryBuilder);

--- a/src/Controllers/PersonFieldsController.php
+++ b/src/Controllers/PersonFieldsController.php
@@ -100,11 +100,13 @@ class PersonFieldsController extends BaseController
     /**
      * Returns data about all person fields
      *
+     * @param integer $options['limit']                 (optional) For pagination, the limit of entries to be returned
+     * @param integer $options['start']                 (optional) For pagination, the position that represents the first result for the page
      * @return \Pipedrive\Utils\JsonSerializer response from the API call
      * @throws APIException Thrown if API call fails
      */
     public function getAllPersonFields(
-        $options
+        $options = array()
     ) {
         //check or get oauth token
         OAuthManager::getInstance()->checkAuthorization();

--- a/src/Utils/CamelCaseHelper.php
+++ b/src/Utils/CamelCaseHelper.php
@@ -6,7 +6,11 @@ class CamelCaseHelper
 {
     public static function keysToCamelCase($input)
     {
-        if ($input instanceof \DateTime) {
+        if (is_null($input)) {
+            return null;
+        }
+        
+        if ($input instanceof \DateTime || is_string($input)) {
             return $input;
         }
 

--- a/tests/Controllers/PersonFieldsControllerTest.php
+++ b/tests/Controllers/PersonFieldsControllerTest.php
@@ -46,11 +46,15 @@ class PersonFieldsControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testTestGetAllPersonFields()
     {
+        // Parameters for the API call
+        $input = array();
+        $input['start'] = 0;
+        $input['limit'] = null;
 
         // Set callback and perform API call
         self::$controller->setHttpCallBack($this->httpResponse);
         try {
-            self::$controller->getAllPersonFields();
+            self::$controller->getAllPersonFields($input);
         } catch (APIException $e) {
         }
 


### PR DESCRIPTION
This adds the missing support for pagination parameters in getAllPersonFields.

**How to test**
- Checkout this branch;
- Set up an app as instructed in the repo's readme, but add your local repo to compose and add this branch's contents as a dependency instead of pipedrive/pipedrive, or simply replace the contents of pipedrive/pipedrive in your app's vendor directory with this branch contents;
- Autoload a file with the code bellow to try it out, don't forget to replace the path to the autoload lib with one that works in your app, plus replace the value:
-  $apiToken with your Pipedrive API Token
Feel free to change the parameters as well, to test different limits and starting pages.
```php
<?php

require_once __DIR__.'/../vendor/autoload.php';

session_start();

$apiToken = '<YOUR API TOKEN HERE>';
$start = 0;
$limit = 2;

$client = new Pipedrive\Client(null, null, null, $apiToken); 

try {
     echo '<div><h2>Get all person fields</h2><div>';

     $collect['start'] = $start;
     $collect['limit'] = $limit;

     $response = $client->getPersonFields()->getAllPersonFields($collect);

     echo '<pre>';
     var_dump(json_encode($response->data, JSON_PRETTY_PRINT));
     echo '</pre>';

} catch (\Pipedrive\APIException $e) {
    echo $e;
}
```

The change also adds a failsafe in CamelCaseHelper, to prevent it from breaking if a field has an non-iterable result as the value. You can use this script to try it out:

```php
<?php

require_once __DIR__.'/../vendor/autoload.php';

use Pipedrive\Utils\CamelCaseHelper;

$empty = new stdClass();
$null = null;
$array = array();
$string = "";

$emptyFields = new stdClass();
$emptyFields->null_name = null;
$emptyFields->empty_array_of_pets = array();
$emptyFields->no_string_quote = '';

echo '<div><h2>Empty object</h2><div>';
echo '<pre>';
    var_dump(json_encode(CamelCaseHelper::keysToCamelCase($empty)));
echo '</pre>';

echo '<div><h2>Null</h2><div>';     
echo '<pre>';
    var_dump(CamelCaseHelper::keysToCamelCase($null));
echo '</pre>';

echo '<div><h2>Empty array</h2><div>';     
echo '<pre>';
    var_dump(CamelCaseHelper::keysToCamelCase($array));
echo '</pre>';

echo '<div><h2>Empty string</h2><div>';     
echo '<pre>';
    var_dump(CamelCaseHelper::keysToCamelCase($string));
echo '</pre>';

echo '<div><h2>Object with empty fields</h2><div>';     
echo '<pre>';
    var_dump(json_encode(CamelCaseHelper::keysToCamelCase($emptyFields), JSON_PRETTY_PRINT));
echo '</pre>';

```

<img width="505" alt="image" src="https://user-images.githubusercontent.com/11083760/183065870-68fbdc88-9209-4887-84bc-cdaf1f1007c5.png">
