### PR TITLE
Type [ProductField->options]: [string|null] -> [array|null]

### DIFF
--- a/src/Models/ProductField.php
+++ b/src/Models/ProductField.php
@@ -24,7 +24,7 @@ class ProductField implements JsonSerializable
     /**
      * When field_type is either set or enum, possible options must be supplied as a JSON-encoded
      * sequential array, for example: ["red","blue","lilac"]
-     * @var string|null $options public property
+     * @var array|null $options public property
      */
     public $options;
 


### PR DESCRIPTION
When the options are set and API returns array of options, PHP throws the follow error:

```
at /vendor/pipedrive/pipedrive/src/Controllers/ProductFieldsController.php:149
24. apimatic\jsonmapper\JsonMapper->map()
  at /vendor/apimatic/jsonmapper/src/JsonMapper.php:319
25. apimatic\jsonmapper\JsonMapper->mapArray()
  at /vendor/apimatic/jsonmapper/src/JsonMapper.php:247
26. apimatic\jsonmapper\JsonMapper->map()
  at /vendor/apimatic/jsonmapper/src/JsonMapper.php:523
27. settype()
  at /vendor/apimatic/jsonmapper/src/JsonMapper.php:204
28. Illuminate\Exception\Handler->handleError()
  at :

---- Error Details ----
ErrorException thrown
  at /vendor/apimatic/jsonmapper/src/JsonMapper.php:204

Array to string conversion
```

This PR sets the correct type and should fix the issue.
