### PR TITLE
Add pipeline_id into deals summary API

### DIFF
--- a/src/Controllers/DealsController.php
+++ b/src/Controllers/DealsController.php
@@ -261,10 +261,11 @@ class DealsController extends BaseController
 
         //process optional query parameters
         APIHelper::appendUrlWithQueryParameters($_queryBuilder, array (
-            'status'    => $this->val($options, 'status'),
-            'filter_id' => $this->val($options, 'filterId'),
-            'user_id'   => $this->val($options, 'userId'),
-            'stage_id'  => $this->val($options, 'stageId'),
+            'status'        => $this->val($options, 'status'),
+            'filter_id'     => $this->val($options, 'filterId'),
+            'user_id'       => $this->val($options, 'userId'),
+            'stage_id'      => $this->val($options, 'stageId'),
+            'pipeline_id'   => $this->val($options, 'pipelineId'),
         ));
 
         //validate and preprocess url

--- a/tests/Controllers/DealsControllerTest.php
+++ b/tests/Controllers/DealsControllerTest.php
@@ -217,6 +217,7 @@ class DealsControllerTest extends \PHPUnit_Framework_TestCase
         $input['filterId'] = null;
         $input['userId'] = null;
         $input['stageId'] = null;
+        $input['pipelineId'] = null;
 
         // Set callback and perform API call
         $result = null;


### PR DESCRIPTION
I'm trying to add `pipeLineId` filter in the deals summary API. Actually, this filter doesn't exist in API Docs. But it has been available in Pipedrive CRM API. I believe this pull request adds a new filter when we want to get the total count of deals with `pipelineId` which will make the project more dev-friendly.

![image](https://user-images.githubusercontent.com/12946698/236374179-1b893fc0-de19-4cd4-89d3-aa11da7e8f39.png)

 
`at src/Controllers/DealsController.php`
![image](https://user-images.githubusercontent.com/12946698/236373898-6cb3816d-2ba7-4416-96ee-3de4421a5f32.png)

`tests/Controllers/DealsControllerTest.php`
![image](https://user-images.githubusercontent.com/12946698/236373966-e7833cda-debb-41bb-807e-2f86983c20c8.png)



