### PR TITLE
Release with fixes for namespace issues in openAPITypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [6.1.0](https://github.com/pipedrive/client-php/compare/6.0.0...6.1.0) (2023-09-05)
+
+### Fixed
+
+- Resolved namespace issues in `$openAPITypes` for `ProductAttachmentDetails`, `AddProductAttachmentDetails`, `BaseMailThread`, and `FieldTypeAsString` (#91) models
+
 ## [6.0.0](https://github.com/pipedrive/client-php/compare/5.1.0...6.0.0) (2023-08-30)
 
 ### Removed

--- a/lib/Model/Field.php
+++ b/lib/Model/Field.php
@@ -67,7 +67,7 @@ class Field implements ModelInterface, ArrayAccess, JsonSerializable
         'key' => 'string',
         'name' => 'string',
         'order_nr' => 'int',
-        'field_type' => 'FieldTypeAsString',
+        'field_type' => '\Pipedrive\Model\FieldTypeAsString',
         'add_time' => 'string',
         'update_time' => 'string',
         'last_updated_by_user_id' => 'int',

--- a/lib/Model/GetAddProductAttachementDetails.php
+++ b/lib/Model/GetAddProductAttachementDetails.php
@@ -64,7 +64,7 @@ class GetAddProductAttachementDetails implements ModelInterface, ArrayAccess, Js
       */
     protected static array $openAPITypes = [
         'success' => 'bool',
-        'data' => 'AddProductAttachmentDetails'
+        'data' => '\Pipedrive\Model\AddProductAttachmentDetails'
     ];
 
     /**

--- a/lib/Model/GetProductAttachementDetails.php
+++ b/lib/Model/GetProductAttachementDetails.php
@@ -64,7 +64,7 @@ class GetProductAttachementDetails implements ModelInterface, ArrayAccess, JsonS
       */
     protected static array $openAPITypes = [
         'success' => 'bool',
-        'data' => 'ProductAttachmentDetails'
+        'data' => '\Pipedrive\Model\ProductAttachmentDetails'
     ];
 
     /**

--- a/lib/Model/MailThreadOne.php
+++ b/lib/Model/MailThreadOne.php
@@ -64,7 +64,7 @@ class MailThreadOne implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPITypes = [
         'success' => 'bool',
-        'data' => 'BaseMailThread'
+        'data' => '\Pipedrive\Model\BaseMailThread'
     ];
 
     /**

--- a/lib/Model/MailThreadOneAllOf.php
+++ b/lib/Model/MailThreadOneAllOf.php
@@ -63,7 +63,7 @@ class MailThreadOneAllOf implements ModelInterface, ArrayAccess, JsonSerializabl
       * @phpsalm-var array<string, string>
       */
     protected static array $openAPITypes = [
-        'data' => 'BaseMailThread'
+        'data' => '\Pipedrive\Model\BaseMailThread'
     ];
 
     /**

--- a/test/Deals/DealFieldsApiTest.php
+++ b/test/Deals/DealFieldsApiTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Pipedrive\Api\DealFieldsApi;
+use Pipedrive\Api\DealsApi;
+use Pipedrive\Configuration;
+use Pipedrive\Tests\Unit\TestCase;
+
+uses(TestCase::class)->group('unit');
+
+it('lists deal fields', function () {
+    $config = new Configuration();
+
+    $mock = $this->httpMock();
+    $mock->append(
+        new Response(200, [], json_encode([
+            'data' => [
+                [
+                    'id' => 1,
+                    'field_type' => 'varchar',
+                    'key' => 'title',
+                    'name' => 'Title',
+                    'order_nr' => 2
+                ],
+            ],
+        ])),
+    );
+
+    $handlerStack = HandlerStack::create($mock);
+
+    $apiInstance = new DealFieldsApi(
+        new Client(['handler' => $handlerStack]),
+        $config,
+    );
+    $result = $apiInstance->getDealFields(0, 10);
+
+    expect($mock->getLastRequest()->getUri()->getQuery())->toEqual('start=0&limit=10')
+        ->and($result->getData())->toHaveLength(1);
+});

--- a/test/Deals/DealsApiTest.php
+++ b/test/Deals/DealsApiTest.php
@@ -4,6 +4,8 @@ use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Pipedrive\Api\DealsApi;
+use Pipedrive\Model\NewDealProduct;
+use Pipedrive\Model\UpdateDealProduct;
 use Pipedrive\Configuration;
 use Pipedrive\Tests\Unit\TestCase;
 
@@ -59,4 +61,104 @@ it('fetches one deal', function () {
 
     expect($mock->getLastRequest()->getUri())->toEqual('https://api.pipedrive.com/v1/deals/1')
         ->and($result->getData()->getId())->toBe(1);
+});
+
+it('attach a product to a deal', function () {
+    $config = new Configuration();
+
+    $mock = $this->httpMock();
+    $mock->append(
+        new Response(200, [], json_encode([
+            'data' => [
+                'id' => 777,
+                'product_id' => 1,
+                'quantity' => 1,
+                'discount' => 1,
+                'product_id' => 1,
+                'discount_type' => 'percentage',
+                'duration' => 1,
+                'tax' => 0,
+                'tax_method' => 'inclusive',
+                'enabled_flag' => true,
+                'company_id' => 1,
+                'deal_id' => 1,
+                'sum' => 1,
+                'currency' => 'USD',
+                'add_time' => '2023-09-05 06:22:06',
+                'last_edit' => '2023-09-05 06:22:06',
+                'active_flag' => true,
+                'name' => 'Paper Rocket'
+            ],
+        ])),
+    );
+
+    $new_deal_product = new NewDealProduct();
+
+    $new_deal_product->setProductId(1);
+    $new_deal_product->setItemPrice(1);
+    $new_deal_product->setQuantity(1);
+
+    $handlerStack = HandlerStack::create($mock);
+
+    $client = new Client(['handler' => $handlerStack]);
+
+    $apiInstance = new DealsApi(
+        $client,
+        $config,
+    );
+    $result = $apiInstance->addDealProduct(1, $new_deal_product);
+
+    expect($mock->getLastRequest()->getUri())->toEqual('https://api.pipedrive.com/v1/deals/1/products')
+        ->and($result->getData()->getId())->toBe(777);
+});
+
+it('update a product attached to a deal', function () {
+    $config = new Configuration();
+
+    $mock = $this->httpMock();
+    $mock->append(
+        new Response(200, [], json_encode([
+            'data' => [
+                'id' => 777,
+                'product_id' => 1,
+                'quantity' => 1,
+                'discount' => 1,
+                'product_id' => 1,
+                'discount_type' => 'percentage',
+                'duration' => 1,
+                'tax' => 0,
+                'tax_method' => 'inclusive',
+                'enabled_flag' => true,
+                'company_id' => 1,
+                'deal_id' => 1,
+                'sum' => 1,
+                'currency' => 'USD',
+                'add_time' => '2023-09-05 06:22:06',
+                'last_edit' => '2023-09-05 06:22:06',
+                'active_flag' => true,
+                'name' => 'Paper Rocket'
+            ],
+        ])),
+    );
+
+    $update_deal_product = new UpdateDealProduct();
+
+    $update_deal_product->setProductId(1);
+    $update_deal_product->setItemPrice(100);
+    $update_deal_product->setQuantity(1);
+
+    $encoded_deal_product = rawurlencode(json_encode($update_deal_product, JSON_PRETTY_PRINT));
+
+    $handlerStack = HandlerStack::create($mock);
+
+    $client = new Client(['handler' => $handlerStack]);
+
+    $apiInstance = new DealsApi(
+        $client,
+        $config,
+    );
+    $result = $apiInstance->updateDealProduct(1, $update_deal_product);
+
+    expect($mock->getLastRequest()->getUri())->toEqual("https://api.pipedrive.com/v1/deals/1/products/{$encoded_deal_product}")
+        ->and($result->getData()->getId())->toBe(777);
 });

--- a/test/MailThreads/MailThreadsApiTest.php
+++ b/test/MailThreads/MailThreadsApiTest.php
@@ -36,6 +36,34 @@ test('get mail threads', function () {
         ->and($result[0]->getArchivedFlag())->toBe(0);
 });
 
+
+test('get one mail thread', function () {
+    $config = new Configuration();
+
+    $mock = $this->httpMock();
+    $mock->append(
+        new Response(200, [], json_encode([
+            'data' => [
+                'id' => 42, 'archived_flag' => 0
+            ],
+        ])),
+    );
+
+    $handlerStack = HandlerStack::create($mock);
+
+    $apiInstance = new MailboxApi(
+        new Client(['handler' => $handlerStack]),
+        $config
+    );
+
+    $result = $apiInstance->getMailThread(42)->getData();
+
+    expect($mock->getLastRequest()->getUri())->toEqual('https://api.pipedrive.com/v1/mailbox/mailThreads/42')
+        ->and($result->getId())->toBe(42)
+        ->and($result->getArchivedFlag())->toBe(0);
+});
+
+
 test('put mail threads', function () {
     $config = new Configuration();
 


### PR DESCRIPTION
### Fixed

- namespace issues in `$openAPITypes` for `ProductAttachmentDetails`, `AddProductAttachmentDetails`, `BaseMailThread`, and `FieldTypeAsString` (#91) models