### PR TITLE
Expand FieldTypeAsString enum

### DIFF
--- a/lib/Model/AdditionalDataWithOffsetPagination.php
+++ b/lib/Model/AdditionalDataWithOffsetPagination.php
@@ -66,7 +66,7 @@ class AdditionalDataWithOffsetPagination implements ModelInterface, ArrayAccess,
       * @phpsalm-var array<string, string>
       */
     protected static array $openAPITypes = [
-        'pagination' => 'AdditionalData'
+        'pagination' => '\Pipedrive\Model\AdditionalData'
     ];
 
     /**

--- a/lib/Model/FieldTypeAsString.php
+++ b/lib/Model/FieldTypeAsString.php
@@ -77,6 +77,14 @@ class FieldTypeAsString
 
     const VISIBLE_TO = 'visible_to';
 
+    const INT = 'int';
+
+    const STAGE = 'stage';
+
+    const STATUS = 'status';
+
+    const VARCHAR_OPTIONS = 'varchar_options';
+
     /**
      * Gets allowable values of the enum
      * @return (string|int)[]
@@ -100,7 +108,11 @@ class FieldTypeAsString
             self::USER,
             self::VARCHAR,
             self::VARCHAR_AUTO,
-            self::VISIBLE_TO
+            self::VISIBLE_TO,
+            self::INT,
+            self::STAGE,
+            self::STATUS,
+            self::VARCHAR_OPTIONS,
         ];
     }
 }

--- a/lib/Traits/RawData.php
+++ b/lib/Traits/RawData.php
@@ -25,6 +25,7 @@
  */
 
 namespace Pipedrive\Traits;
+use Throwable;
 
 /**
  * PHP version 7.3
@@ -63,7 +64,7 @@ trait RawData
             } else {
                 $this->rawData = $rawData;
             }
-        } catch (Error) {
+        } catch (Throwable $e) {
             $this->rawData = $rawData;
         }
     }

--- a/lib/Traits/RawData.php
+++ b/lib/Traits/RawData.php
@@ -57,6 +57,14 @@ trait RawData
      */
     public function setRawData(mixed $rawData): void
     {
-        $this->rawData = property_exists($rawData, 'data') ? $rawData->data : $rawData;
+        try {
+            if (property_exists($rawData, 'data')) {
+                $this->rawData = $rawData->data;
+            } else {
+                $this->rawData = $rawData;
+            }
+        } catch (Error) {
+            $this->rawData = $rawData;
+        }
     }
 }

--- a/test/Deals/DealFieldsApiTest.php
+++ b/test/Deals/DealFieldsApiTest.php
@@ -18,11 +18,39 @@ it('lists deal fields', function () {
         new Response(200, [], json_encode([
             'data' => [
                 [
+                    'id' => 0,
+                    'field_type' => 'int',
+                    'key' => 'id',
+                    'name' => 'ID',
+                    'order_nr' => 0
+                ],
+                [
                     'id' => 1,
                     'field_type' => 'varchar',
                     'key' => 'title',
                     'name' => 'Title',
+                    'order_nr' => 1
+                ],
+                [
+                    'id' => 2,
+                    'field_type' => 'status',
+                    'key' => 'status',
+                    'name' => 'Status',
                     'order_nr' => 2
+                ],
+                [
+                    'id' => 3,
+                    'field_type' => 'stage',
+                    'key' => 'stage_id',
+                    'name' => 'Stage',
+                    'order_nr' => 3
+                ],
+                [
+                    'id' => 4,
+                    'field_type' => 'varchar_options',
+                    'key' => 'lost_reason',
+                    'name' => 'Lost Reason',
+                    'order_nr' => 4
                 ],
             ],
         ])),
@@ -37,5 +65,5 @@ it('lists deal fields', function () {
     $result = $apiInstance->getDealFields(0, 10);
 
     expect($mock->getLastRequest()->getUri()->getQuery())->toEqual('start=0&limit=10')
-        ->and($result->getData())->toHaveLength(1);
+    ->and($result->getData())->toHaveLength(5);
 });


### PR DESCRIPTION
The getDealFields() method throws an exception:

```
Invalid value for enum '\Pipedrive\Model\FieldTypeAsString', must be one of: 'address', 'date', 'daterange', 'double', 'enum', 'monetary', 'org', 'people', 'phone', 'set', 'text', 'time', 'timerange', 'user', 'varchar', 'varchar_auto', 'visible_to'
```

There are field types in the response which were not being included in the enum.