### PR TITLE
add type checking for object on rawData setter

### DIFF
--- a/lib/Traits/RawData.php
+++ b/lib/Traits/RawData.php
@@ -57,6 +57,6 @@ trait RawData
      */
     public function setRawData(mixed $rawData): void
     {
-        $this->rawData = property_exists($rawData, 'data') ? $rawData->data : $rawData;
+        $this->rawData = is_object($rawData) && property_exists($rawData, 'data') ? $rawData->data : $rawData;
     }
 }


### PR DESCRIPTION
When fetching a newly created and empty pipeline via the getPipeline-method, the following error occurs:

```
"message": "property_exists(): Argument #1 ($object_or_class) must be of type object|string, array given",
"exception": "TypeError"
```

The pipedrive API returns
```
{
	"success": true,
	"data": {
		"id": 7,
		"name": "New Pipeline",
		"url_title": "New-Pipeline",
		"order_nr": 4,
		"active": true,
		"deal_probability": true,
		"add_time": "2024-09-14 12:02:41",
		"update_time": "2024-09-14 12:02:41",
		"selected": true,
		"deals_summary": []
	}
}
```

whereas a pipeline containing a deal returns a deals_summary object as seen here:

```
...
"deals_summary": {
	"per_stages": {
		"19": {
			"USD": {
				"count": 4,
				"value": 0,
				...
			}
		}
	}
}
```