### PR TITLE
Update Configuration.php to use v2 endpoints

### DIFF
--- a/lib/versions/v2/Configuration.php
+++ b/lib/versions/v2/Configuration.php
@@ -674,7 +674,7 @@ class Configuration
         }
 
         if (property_exists($oAuthToken, 'api_domain') && $oAuthToken->api_domain !== null) {
-            $this->setHost($oAuthToken->api_domain.'/v1');
+            $this->setHost($oAuthToken->api_domain.'/v2');
         }
 
         if (is_callable($this->getOAuthTokenUpdateCallback())) {
@@ -847,7 +847,7 @@ class Configuration
     {
         return [
             [
-                "url" => "https://api.pipedrive.com/v1",
+                "url" => "https://api.pipedrive.com/v2",
                 "description" => "No description provided",
             ]
         ];


### PR DESCRIPTION
## Description

Update URL strings in Configuration.php to use `v2` instead of `v1`. With `v1` a token refresh sets the host URL to point to version `v1` of the API, which does not support actions like `DealsApi::getAdditionalDiscounts()`.

## Type of PR
 - 🐛 Bug Fix

## Manual testing

To reproduce 

```

use Pipedrive\versions\v2\Configuration as ConfigurationV2;
use Pipedrive\versions\v2\Api\DealsApi as DealsApiV2;
...

// create Configuration for API v2
$config = (new ConfigurationV2());

echo $config->getHost(); // prints https://api.pipedrive.com/api/v2

// set parameters and tokens
$config->setClientId(env('PIPEDRIVE_CLIENT_ID'));
$config->setClientSecret(env('PIPEDRIVE_CLIENT_SECRET'));
$config->setAccessToken($token->access_token);
$config->setRefreshToken($token->refresh_token);

echo $config->getHost(); // prints https://api.pipedrive.com/api/v2

$config->refreshToken();
echo $config->getHost(); // prints https://api.pipedrive.com/api/v1


$dealsApi = new DealsApiV2(null, $config);
$discountResponse = $dealsApi->getAdditionalDiscounts(123);
// fails with  [404] Client error: `GET https://XXXX.pipedrive.com/v1/deals/123/discounts` resulted in a `404 Not Found` response

```

## Automated tests added?

- [ ] 👍 Unit tests
- [ ] 👍 Functional tests
- [ ] 👍 E2E tests
- [X] 🙅 N/A
