### PR TITLE
Use correct /api/v2 path

### DIFF
--- a/lib/versions/v2/Configuration.php
+++ b/lib/versions/v2/Configuration.php
@@ -674,7 +674,7 @@ class Configuration
         }
 
         if (property_exists($oAuthToken, 'api_domain') && $oAuthToken->api_domain !== null) {
-            $this->setHost($oAuthToken->api_domain.'/v2');
+            $this->setHost($oAuthToken->api_domain.'/api/v2');
         }
 
         if (is_callable($this->getOAuthTokenUpdateCallback())) {
@@ -847,7 +847,7 @@ class Configuration
     {
         return [
             [
-                "url" => "https://api.pipedrive.com/v2",
+                "url" => "https://api.pipedrive.com/api/v2",
                 "description" => "No description provided",
             ]
         ];


### PR DESCRIPTION
## Related Tickets & Documents

My issue: https://github.com/pipedrive/client-php/issues/252

Forum entry that helped me solve it: https://devcommunity.pipedrive.com/t/persons-api-v2-returning-html-content/19618

## Description

The configuratio uses the url `.../v2` instead of `.../api/v2` and thus returns `Content-Type: text/html` instead of `Content-Type: application/json`, which can not be correctly handled by the client.

## Type of PR

<!-- Remove the comment blocks to uncomment all applicable types -->
🐛 Bug Fix

## Manual testing

To reproduce:

```
use Pipedrive\versions\v2\Configuration as ConfigurationV2;
use Pipedrive\versions\v2\Api\DealsApi as DealsApiV2;
...

// create Configuration for API v2
$config = (new ConfigurationV2());
$configv2->setDebug(true);
$configv2->setDebugFile(storage_path("pddebug.txt"));

// set parameters and tokens
$config->setClientId(env('PIPEDRIVE_CLIENT_ID'));
$config->setClientSecret(env('PIPEDRIVE_CLIENT_SECRET'));
$config->setAccessToken($token->access_token);
$config->setRefreshToken($token->refresh_token);
$config->refreshToken();

echo $config->getHost(); // prints https://my-company.pipedrive.com/v2


$dealsApi = new DealsApiV2(null, $config);
$discountResponse = $dealsApi->getDeal(123); // this will be empty
```

`pddebug.txt` is
 
```
*   Trying 104.18.188.228:443...
* Connected to my-company.pipedrive.com (104.18.188.228) port 443 (#0)
* ALPN, offering http/1.1
*  CAfile: /etc/ssl/certs/ca-certificates.crt
*  CApath: /etc/ssl/certs
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: CN=pipedrive.com
*  start date: Oct 10 12:16:31 2025 GMT
*  expire date: Jan  8 13:16:25 2026 GMT
*  subjectAltName: host "my-company.pipedrive.com" matched cert's "*.pipedrive.com"
*  issuer: C=US; O=Google Trust Services; CN=WE1
*  SSL certificate verify ok.
> GET /v2/deals/323 HTTP/1.1
Host: pdx-sandbox.pipedrive.com
User-Agent: Pipedrive-SDK-PHP-14.x
Accept: application/json
Content-Type: application/json
Authorization: Bearer xxx

* old SSL session ID is stale, removing
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Date: Sun, 23 Nov 2025 12:14:37 GMT
< Content-Type: text/html <------------------------- should be application/json
...

The problem can be fixed by explicitly setting the `.../api/v2` url:

```
use Pipedrive\versions\v2\Configuration as ConfigurationV2;
use Pipedrive\versions\v2\Api\DealsApi as DealsApiV2;
...

// create Configuration for API v2
$config = (new ConfigurationV2());
$configv2->setDebug(true);
$configv2->setDebugFile(storage_path("pddebug.txt"));

// set parameters and tokens
$config->setClientId(env('PIPEDRIVE_CLIENT_ID'));
$config->setClientSecret(env('PIPEDRIVE_CLIENT_SECRET'));
$config->setAccessToken($token->access_token);
$config->setRefreshToken($token->refresh_token);
$config->refreshToken();

$config->setHost("https://my-company.pipedrive.com/api/v2"); // Explicitly set the correct url

$dealsApi = new DealsApiV2(null, $config);
$discountResponse = $dealsApi->getDeal(123); // now it works
```



## Automated tests added?


- [ ] 👍 Unit tests
- [ ] 👍 Functional tests
- [ ] 👍 E2E tests
- [X ] 🙅 N/A
