### PR TITLE
fix: remove mixed type hints from RawData trait for PHP 7.4 compatibility

### DIFF
--- a/lib/versions/v1/Traits/RawData.php
+++ b/lib/versions/v1/Traits/RawData.php
@@ -37,14 +37,14 @@ trait RawData
     /**
      * @var mixed
      */
-    private mixed $rawData;
+    private $rawData;
 
     /**
      * Get raw data
      *
      * @return mixed
      */
-    public function getRawData(): mixed
+    public function getRawData()
     {
         return $this->rawData;
     }
@@ -55,7 +55,7 @@ trait RawData
      * @param mixed $rawData
      * @return void
      */
-    public function setRawData(mixed $rawData): void
+    public function setRawData($rawData): void
     {
         $this->rawData = is_object($rawData) && property_exists($rawData, 'data') ? $rawData->data : $rawData;
     }

--- a/lib/versions/v2/Traits/RawData.php
+++ b/lib/versions/v2/Traits/RawData.php
@@ -37,14 +37,14 @@ trait RawData
     /**
      * @var mixed
      */
-    private mixed $rawData;
+    private $rawData;
 
     /**
      * Get raw data
      *
      * @return mixed
      */
-    public function getRawData(): mixed
+    public function getRawData()
     {
         return $this->rawData;
     }
@@ -55,7 +55,7 @@ trait RawData
      * @param mixed $rawData
      * @return void
      */
-    public function setRawData(mixed $rawData): void
+    public function setRawData($rawData): void
     {
         $this->rawData = is_object($rawData) && property_exists($rawData, 'data') ? $rawData->data : $rawData;
     }


### PR DESCRIPTION
## Summary

- Remove `mixed` native type hints from `RawData` trait (v1 and v2) to restore PHP 7.4 compatibility
- Keep PHPDoc `@var mixed`, `@param mixed`, and `@return mixed` annotations for documentation
- Fully backward compatible with PHP 8.x (no type hint = accepts any type, same as `mixed`)

## Problem

`composer.json` declares `"php": "^7.4 || ^8.0"`, but the `mixed` type (property, parameter, and return type) was introduced in PHP 8.0. On PHP 7.4, it causes a fatal error:

```
Argument 1 passed to Pipedrive\versions\v2\Model\DealItem::setRawData() must be an instance of
Pipedrive\versions\v2\Traits\mixed, instance of stdClass given
```

PHP 7.4 interprets `mixed` as a class name in the current namespace instead of the native type.

## Files changed

- `lib/versions/v1/Traits/RawData.php`
- `lib/versions/v2/Traits/RawData.php`

Closes #279