### PR TITLE
Upgrade Pest to ^3.0 for PHP 8.5 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "guzzlehttp/psr7": "^2.0"
     },
     "require-dev": {
-        "pestphp/pest": "^2.0",
+        "pestphp/pest": "^3.0",
         "phpstan/phpstan": "^1.10"
     },
     "autoload": {


### PR DESCRIPTION
## Related Tickets & Documents

## Description

`pestphp/pest ^2.0` pins PHPUnit 10.x. There is no `brianium/paratest` release that supports both PHPUnit 10.x and PHP 8.5, so `composer install` can no longer resolve the dev dependencies on PHP 8.5 (which the latest `composer` image now ships).

Upgrading to `pestphp/pest ^3.0` resolves cleanly (PHPUnit 11.x, all PHP 8.5 compatible). The existing functional test suite uses only stable Pest syntax and passes unchanged — no v2→v3 breaking changes apply.

## Type of PR

- 🐛 Bug Fix

## Manual testing

Ran `composer install` followed by `composer test` on PHP 8.5: dependencies resolve and all tests pass.

## Automated tests added?

- [x] 🙅 N/A